### PR TITLE
Use GreengageDB/greengage-ci/; Update 'ref' input added

### DIFF
--- a/.github/workflows/greengage-reusable-build.yml
+++ b/.github/workflows/greengage-reusable-build.yml
@@ -22,6 +22,10 @@ on:
         required: false
         type: string
         default: ''
+      ref:
+        description: 'Branch or ref to checkout'
+        required: false
+        type: string
     secrets:
       ghcr_token:
         description: 'GitHub token for GHCR access'
@@ -30,15 +34,20 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # runs-on: docker
-    # container:
-    #   image: docker:dind
-    #   options: --privileged
     steps:
       - name: Checkout Greengage repo
+        if: ${{ inputs.ref == '' }}
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
+          submodules: recursive
+          fetch-depth: 0
+      - name: Checkout specified ref
+        if: ${{ inputs.ref != '' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ inputs.ref }}
           submodules: recursive
           fetch-depth: 0
       - name: Create CI directory
@@ -66,10 +75,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Start Docker daemon
-      #   run: |
-      #     dockerd &
-      #     sleep 5  # Wait for dockerd to start
       - name: Build and push base image
         run: |
           BASE_IMAGE_TAG=ghcr.io/${{ github.repository }}/ggdb${{ inputs.version }}-base:${{ inputs.target_os }}${{ inputs.target_os_version }}

--- a/README.md
+++ b/README.md
@@ -1,28 +1,170 @@
-
 # Greengage Reusable Docker Build Workflow
 
 [![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-Reusable_Workflow-blue?logo=githubactions)](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
 
 ## Overview
 
-This reusable GitHub Actions workflow automates the building and publishing of Greengage Database (GGDB) Docker images to GitHub Container Registry (GHCR). It supports:
+This reusable GitHub Actions workflow, maintained by **GreenData**, automates the building and publishing of **Greengage Database (GGDB)** Docker images to GitHub Container Registry (GHCR). It is part of the `GreengageDB/greengage-ci` repository, a fork of `GreengageDB/greengage-ci`. The workflow supports:
 
-- Multi-version builds (GGDB 6/7)
-- Multi-OS builds (Ubuntu, CentOS, etc.)
+- Multi-version builds (GGDB 6` or `7.x`)
+- Multi-OS builds (`Ubuntu 22`, `CentOS 7`, `RockyLinux 8`)
+- Python3 configuration for `Ubuntu 22` with version `6`
 - Base image caching
 - Automatic tagging strategy
 - CI repository fallback mechanism
 
+The `manual_build.yml` workflow allows manual triggering with a user-friendly interface to select the target branch and OS, ensuring compatibility and streamlined builds.
+The `manual_build.yml` shoul be placed in target repositor at `.github/workflows/greengage-build-manual.yml`.
+
 ## Usage
 
-### Input Parameters
+### Manual Build Workflow
+
+The `manual_build.yml` workflow is designed for manual execution via GitHub Actions' `workflow_dispatch`. It determines the Greengage version based on the selected branch and validates OS compatibility.
+
+#### Input Parameters
+
+| Parameter | Description | Required | Default | Options |
+|-----------|-------------|----------|---------|---------|
+| `target_branch` | Target branch to checkout and build | Yes | `main` | `main` (version `6`), `7.x` (version `7`) |
+| `os_combination` | Target OS (must be compatible with version) | Yes | `Ubuntu 22` | `CentOS 7 (for 6.x only)`, `Ubuntu 22`, `RockyLinux 8 (for 7.x only)` |
+| `logLevel` | Log level for the build | Yes | `warning` | `info`, `warning`, `debug` |
+| `debug_mode` | Enable debug mode | No | `false` | `true`, `false` |
+
+#### Version Mapping
+
+- Branch `main` → Version `6`
+- Branch `7.x` → Version `7`
+
+#### OS Compatibility
+
+- Version `6`: Compatible with `CentOS 7 (for 6.x only)` and `Ubuntu 22`
+- Version `7`: Compatible with `RockyLinux 8 (for 7.x only)` and `Ubuntu 22`
+
+#### Python3 Configuration
+
+- `python3=python3` (command name) is set for `Ubuntu 22` with version `6`.
+- Empty (`python3=`) for all other combinations.
+
+#### Example Implementation
+
+To trigger a manual build, use the following configuration in `.github/workflows/manual_build.yml` within the `GreengageDB/greengage` repository:
+
+```yaml
+name: Greengage Manual Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Target branch to checkout and build'
+        required: true
+        default: 'main'
+        type: choice
+        options:
+          - '7.x'
+          - 'main'
+      os_combination:
+        description: 'Target OS (MUST be compatible with Version)'
+        required: true
+        default: 'Ubuntu 22'
+        type: choice
+        options:
+          - 'CentOS 7 (for 6.x only)'
+          - 'Ubuntu 22'
+          - 'RockyLinux 8 (for 7.x only)'
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
+      debug_mode:
+        description: 'Enable debug mode'
+        type: boolean
+        default: false
+
+jobs:
+  parse-os:
+    runs-on: ubuntu-latest
+    outputs:
+      target_os: ${{ steps.parse_os.outputs.target_os }}
+      target_os_version: ${{ steps.parse_os.outputs.target_os_version }}
+      python3: ${{ steps.parse_os.outputs.python3 }}
+      version: ${{ steps.parse_os.outputs.version }}
+    steps:
+      - name: Parse OS combination
+        id: parse_os
+        run: |
+          # Set version based on target_branch
+          case "${{ inputs.target_branch }}" in
+            "main")
+              version="6"
+              ;;
+            "7.x")
+              version="7"
+              ;;
+          esac
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+          # Validate OS combination and parse
+          case "${{ inputs.os_combination }}" in
+            "CentOS 7 (for 6.x only)")
+              if [[ "$version" != "6" ]]; then
+                echo "Error: CentOS 7 is only compatible with version 6" >&2
+                exit 1
+              fi
+              echo "target_os=centos" >> $GITHUB_OUTPUT
+              echo "target_os_version=7" >> $GITHUB_OUTPUT
+              echo "python3=" >> $GITHUB_OUTPUT
+              ;;
+            "Ubuntu 22")
+              echo "target_os=ubuntu" >> $GITHUB_OUTPUT
+              echo "target_os_version=22" >> $GITHUB_OUTPUT
+              if [[ "$version" == "6" ]]; then
+                echo "python3=python3" >> $GITHUB_OUTPUT
+              else
+                echo "python3=" >> $GITHUB_OUTPUT
+              fi
+              ;;
+            "RockyLinux 8 (for 7.x only)")
+              if [[ "$version" != "7" ]]; then
+                echo "Error: RockyLinux 8 is only compatible with version 7" >&2
+                exit 1
+              fi
+              echo "target_os=rockylinux" >> $GITHUB_OUTPUT
+              echo "target_os_version=8" >> $GITHUB_OUTPUT
+              echo "python3=" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+  manual-build:
+    needs: parse-os
+    uses: GreengageDB/greengage-ci/.github/workflows/greengage-reusable-build.yml@main
+    with:
+      version: ${{ needs.parse-os.outputs.version }}
+      target_os: ${{ needs.parse-os.outputs.target_os }}
+      target_os_version: ${{ needs.parse-os.outputs.target_os_version }}
+      python3: ${{ needs.parse-os.outputs.python3 }}
+      ref: ${{ inputs.target_branch }}
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Reusable Workflow Inputs
+
+The `greengage-reusable-build.yml` workflow accepts the following inputs:
 
 | Parameter | Description | Required | Default |
 |-----------|-------------|----------|---------|
-| `version` | GGDB version (e.g., "6" or "7") | Yes | - |
-| `target_os` | Target OS (e.g., "ubuntu") | Yes | - |
-| `target_os_version` | OS version (e.g., "22") | Yes | - |
-| `python3` | Python3 build argument | No | `''` |
+| `version` | GGDB version (e.g., `6` or `7`) | Yes | - |
+| `target_os` | Target OS (e.g., `ubuntu`, `centos`, `rockylinux`) | Yes | - |
+| `target_os_version` | OS version (e.g., `22`, `7`, `8`) | Yes | - |
+| `python3` | Python3 build argument (e.g., `python3` or empty) | No | `''` |
+| `ref` | Branch or ref to checkout | No | `''` |
 
 ### Secrets
 
@@ -30,21 +172,23 @@ This reusable GitHub Actions workflow automates the building and publishing of G
 |--------|-------------|
 | `ghcr_token` | GitHub token with `write:packages` permission |
 
-### Example Implementation
+### Example for Automated Builds
+
+For automated builds triggered by `push` or `tag` events, you can configure workflows like this:
 
 ```yaml
-name: Build main Branch 6.x
+name: Greengage Auto Build
 
 on:
   push:
-    branches:
-      - 'main'
-    tags:
-      - '6.*'
+    tags: ['6.*']
+  pull_request:
+    branches: ['*']
+    tags: ['6.*']
 
 jobs:
   build-v6-centos7:
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@main
+    uses: magf/greengage-ci/.github/workflows/greengage-reusable-build.yml@main
     with:
       version: 6
       target_os: centos
@@ -54,7 +198,7 @@ jobs:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
   build-v6-ubuntu22:
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@main
+    uses: magf/greengage-ci/.github/workflows/greengage-reusable-build.yml@main
     with:
       version: 6
       target_os: ubuntu
@@ -62,16 +206,15 @@ jobs:
       python3: python3
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
-
 ```
 
 ## Workflow Steps
 
 ### 1. Repository Setup
 
-- Checks out main repository with submodules
+- Checks out the main repository (`GreengageDB/greengage`) with the specified branch (`ref`) or default branch if `ref` is empty
 - Creates CI directory structure
-- Checks out CI repository or falls back to local `ci/` directory
+- Checks out the CI repository (`GreengageDB/greengage-ci`) or falls back to local `ci/` directory
 
 ### 2. Docker Configuration
 
@@ -84,8 +227,10 @@ jobs:
 - Builds and pushes OS-specific base image using:
 
   ```Dockerfile
-  ci/Dockerfile.ubuntu22
+  ci/Dockerfile.<target_os><target_os_version>
   ```
+
+  Example: `ci/Dockerfile.ubuntu22`
 
 ### 4. Tag Management
 
@@ -101,8 +246,10 @@ graph TD
 - Builds GGDB image with structure:
 
   ```text
-  ghcr.io/<org>/<repo>/ggdb7_ubuntu22:<tag>
+  ghcr.io/GreengageDB/greengage/ggdb<version>_<target_os><target_os_version>:<tag>
   ```
+
+  Example: `ghcr.io/GreengageDB/greengage/ggdb6_ubuntu22:6.28.0`
 
 - Uses multi-layer caching:
   1. Base image layer
@@ -110,28 +257,33 @@ graph TD
 - For tagged releases:
   - Additional `:latest` tag is pushed
   - No timestamp suffix added
+- Includes build arguments:
+  - `PYTHON3`: Set to `python3` for `Ubuntu 22` with version `6`, otherwise empty
+  - `REPO`, `TARGET_OS`, `TARGET_OS_VERSION`
 
 ## Image Tagging Strategy
 
 | Git Reference | Tag Format | Example |
 |---------------|------------|---------|
 | Tag           | `X.Y.Z` | `7.3.0` |
-| Non-tag       | `X.Y.Z-YYYYMMDDHHMM` | `v6.28.0-202506101230` |
+| Non-tag       | `X.Y.Z-YYYYMMDDHHMM` | `6.28.0-202506101230` |
 
 ## Requirements
 
-1. **CI Repository Structure (example)**:
+1. **CI Repository Structure**:
 
    ```bash
    ci/
    ├── Dockerfile.centos7
-   └── Dockerfile.ubuntu22
+   ├── Dockerfile.ubuntu22
+   ├── Dockerfile.rockylinux8
+   └── ...
    Dockerfile
    ```
 
 2. **Base Dockerfiles**:
-   - Must be named: `Dockerfile.<OS><OS_VERSION>`
-   - Example: `Dockerfile.ubuntu22`
+   - Must be named: `Dockerfile.<target_os><target_os_version>`
+   - Examples: `Dockerfile.ubuntu22`, `Dockerfile.centos7`, `Dockerfile.rockylinux8`
 
 3. **Permissions**:
    - `contents: read` (for repositories)
@@ -141,6 +293,16 @@ graph TD
 
 The workflow implements smart fallbacks:
 
-1. Remote CI repository unavailable → Uses local `ci/` directory
+1. Remote CI repository (`GreengageDB/greengage-ci`) unavailable → Uses local `ci/` directory
 2. Previous images missing → Builds without cache
 3. Invalid tags → Automatically generates timestamp-based tags
+
+## Contributing
+
+This workflow is maintained by **GreenData** in the `GreengageDB/greengage-ci` repository. For issues or contributions, please open a pull request or issue at:
+
+- [GreengageDB/greengage-ci](https://github.com/GreengageDB/greengage-ci)
+
+For Greengage Database development, refer to:
+
+- [GreengageDB/greengage](https://github.com/GreengageDB/greengage)

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ This reusable GitHub Actions workflow, maintained by **GreenData**, automates th
 - Automatic tagging strategy
 - CI repository fallback mechanism
 
-The `manual_build.yml` workflow allows manual triggering with a user-friendly interface to select the target branch and OS, ensuring compatibility and streamlined builds.
-The `manual_build.yml` shoul be placed in target repositor at `.github/workflows/greengage-build-manual.yml`.
+The `greengage-build-manual.yml` workflow allows manual triggering with a user-friendly interface to select the target branch and OS, ensuring compatibility and streamlined builds.
+The `greengage-build-manual.yml` shoul be placed in target repositor at `.github/workflows/greengage-build-manual.yml`.
 
 ## Usage
 
 ### Manual Build Workflow
 
-The `manual_build.yml` workflow is designed for manual execution via GitHub Actions' `workflow_dispatch`. It determines the Greengage version based on the selected branch and validates OS compatibility.
+The `greengage-build-manual.yml` workflow is designed for manual execution via GitHub Actions' `workflow_dispatch`. It determines the Greengage version based on the selected branch and validates OS compatibility.
 
 #### Input Parameters
 
@@ -48,7 +48,7 @@ The `manual_build.yml` workflow is designed for manual execution via GitHub Acti
 
 #### Example Implementation
 
-To trigger a manual build, use the following configuration in `.github/workflows/manual_build.yml` within the `GreengageDB/greengage` repository:
+To trigger a manual build, use the following configuration in `.github/workflows/greengage-build-manual.yml` within the `GreengageDB/greengage` repository:
 
 ```yaml
 name: Greengage Manual Build

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ on:
 
 jobs:
   build-v6-centos7:
-    uses: magf/greengage-ci/.github/workflows/greengage-reusable-build.yml@main
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@main
     with:
       version: 6
       target_os: centos
@@ -198,7 +198,7 @@ jobs:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
   build-v6-ubuntu22:
-    uses: magf/greengage-ci/.github/workflows/greengage-reusable-build.yml@main
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@main
     with:
       version: 6
       target_os: ubuntu

--- a/greengage-build-manual.yml
+++ b/greengage-build-manual.yml
@@ -90,7 +90,7 @@ jobs:
 
   manual-build:
     needs: parse-os
-    uses: magf/greengage-ci/.github/workflows/greengage-reusable-build.yml@main
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@main
     with:
       version: ${{ needs.parse-os.outputs.version }}
       target_os: ${{ needs.parse-os.outputs.target_os }}

--- a/greengage-build-manual.yml
+++ b/greengage-build-manual.yml
@@ -1,0 +1,101 @@
+name: Greengage Manual Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Target branch to checkout and build'
+        required: true
+        default: 'main'
+        type: choice
+        options:
+          - '7.x'
+          - 'main'
+      os_combination:
+        description: 'Target OS (MUST be compatible with Version)'
+        required: true
+        default: 'Ubuntu 22'
+        type: choice
+        options:
+          - 'CentOS 7 (for 6.x only)'
+          - 'Ubuntu 22'
+          - 'RockyLinux 8 (for 7.x only)'
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
+      debug_mode:
+        description: 'Enable debug mode'
+        type: boolean
+        default: false
+
+jobs:
+  parse-os:
+    runs-on: ubuntu-latest
+    outputs:
+      target_os: ${{ steps.parse_os.outputs.target_os }}
+      target_os_version: ${{ steps.parse_os.outputs.target_os_version }}
+      python3: ${{ steps.parse_os.outputs.python3 }}
+      version: ${{ steps.parse_os.outputs.version }}
+    steps:
+      - name: Parse OS combination
+        id: parse_os
+        run: |
+          # Set version based on target_branch
+          case "${{ inputs.target_branch }}" in
+            "main")
+              version="6"
+              ;;
+            "7.x")
+              version="7"
+              ;;
+          esac
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+          # Validate OS combination and parse
+          case "${{ inputs.os_combination }}" in
+            "CentOS 7 (for 6.x only)")
+              if [[ "$version" != "6" ]]; then
+                echo "Error: CentOS 7 is only compatible with version 6" >&2
+                exit 1
+              fi
+              echo "target_os=centos" >> $GITHUB_OUTPUT
+              echo "target_os_version=7" >> $GITHUB_OUTPUT
+              echo "python3=" >> $GITHUB_OUTPUT
+              ;;
+            "Ubuntu 22")
+              echo "target_os=ubuntu" >> $GITHUB_OUTPUT
+              echo "target_os_version=22" >> $GITHUB_OUTPUT
+              if [[ "$version" == "6" ]]; then
+                echo "python3=python3" >> $GITHUB_OUTPUT
+              else
+                echo "python3=" >> $GITHUB_OUTPUT
+              fi
+              ;;
+            "RockyLinux 8 (for 7.x only)")
+              if [[ "$version" != "7" ]]; then
+                echo "Error: RockyLinux 8 is only compatible with version 7" >&2
+                exit 1
+              fi
+              echo "target_os=rockylinux" >> $GITHUB_OUTPUT
+              echo "target_os_version=8" >> $GITHUB_OUTPUT
+              echo "python3=" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+  manual-build:
+    needs: parse-os
+    uses: magf/greengage-ci/.github/workflows/greengage-reusable-build.yml@main
+    with:
+      version: ${{ needs.parse-os.outputs.version }}
+      target_os: ${{ needs.parse-os.outputs.target_os }}
+      target_os_version: ${{ needs.parse-os.outputs.target_os_version }}
+      python3: ${{ needs.parse-os.outputs.python3 }}
+      ref: ${{ inputs.target_branch }}
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- All links from magf/greengage-ci/ are redirected to repository GreengageDB/greengage-ci/
- Added ref option for manual use from other branches for manual build workflow
- Updated README file