### PR TITLE
Update package workflow and upload-pkgs-to-release README

### DIFF
--- a/.github/actions/upload-pkgs-to-release/README.md
+++ b/.github/actions/upload-pkgs-to-release/README.md
@@ -1,50 +1,34 @@
 # Upload Packages to GitHub Release
 
-This composite GitHub Action orchestrates the package release process by coordinating between the **package building workflow** and **release publishing workflow**. It ensures packages are only uploaded to releases after successful completion of the package generation process.
+This composite GitHub Action creates or updates a GitHub release and uploads packages with standardized names. It waits for the package generation workflow to complete before restoring artifacts from cache and uploading them to the release.
 
-## Workflow Coordination Model
+## Actual version
 
-### Sequence of Operations
+- `greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v25`
 
-1. **Wait for Package Building Workflow Completion**
-   - Polls the specified package generation workflow (`Greengage CI` by default)
-   - Verifies the workflow completed successfully for the exact commit and tag
-   - Provides configurable timeout (default: 4 hours) and polling interval (default: 60 seconds)
+## Purpose
 
-2. **Restore Built Packages from Cache**
-   - Retrieves packages from GitHub Actions cache using commit SHA as key
-   - Cache key format: `{artifact_name}-{commit_sha}`
+The action performs the following operations:
 
-3. **Create Release if Needed**
-   - Creates GitHub release when `create_force` is specified and release doesn't exist
-   - Includes build metadata (commit SHA, workflow run ID) in release notes
-
-4. **Upload Packages with Standardized Names**
-   - Renames packages to fixed pattern: `${PACKAGE_NAME}${VERSION}.${EXT}`
-   - Uploads to release with optional overwrite (`clobber` flag)
+1. **Wait for package generation workflow completion** - Polls the specified workflow until it completes successfully for the current commit and tag
+2. **Restore packages from cache** - Retrieves built packages using commit SHA-based cache key
+3. **Create release if needed** - Optionally creates the GitHub release if it doesn't exist
+4. **Upload packages** - Renames packages to fixed pattern and uploads to release with optional overwrite
 
 ## Inputs
 
 | Name | Required | Default | Description |
 |------|----------|---------|-------------|
-| `artifact_name` | no | `Packages` | Cache key prefix for artifact restoration |
-| `package_name` | no | repo name | Base package name for uploaded files |
-| `release_name` | no | current tag | Target release name (defaults to tag) |
-| `version` | no | empty | Version suffix for package names |
-| `extensions` | no | `deb ddeb rpm` | Space-separated package extensions |
-| `create_force` | no | empty | Force release creation if missing |
-| `clobber` | no | `false` | Overwrite existing release assets |
+| `artifact_name` | no | `Packages` | Artifact name for download and cache key prefix |
+| `package_name` | no | repo name | Base package name for uploaded files (defaults to repository name) |
+| `release_name` | no | current tag | Target release name (defaults to current tag) |
+| `version` | no | empty | Version string to append to package name |
+| `extensions` | no | `deb ddeb rpm` | Space-separated list of package file extensions |
+| `create_force` | no | empty | Force create the release if not exists |
+| `clobber` | no | `false` | Overwrite existing assets if they exist |
 | `ci_wait_timeout` | no | `14400` | Timeout in seconds to wait for CI workflow (4 hours) |
-| `ci_poll_interval` | no | `60` | Poll interval in seconds to check CI workflow status |
-| `workflow_for_waiting` | no | `Greengage CI` | **Name of the package building workflow** to wait for completion |
-
-## Key Features
-
-- **Workflow Coordination**: Ensures package building completes successfully before release upload
-- **Build Status Verification**: Uses GitHub CLI to confirm successful build for specific commit/tag
-- **Cache-based Artifact Transfer**: Reliable package transfer between workflows via GitHub Actions cache
-- **Configurable Timeouts**: Adjustable wait times for CI workflow completion
-- **Manual Recovery Flow**: Clear instructions when cache restoration fails
+| `ci_poll_interval` | no | `60` | Poll interval in seconds to check CI workflow status (1 minute) |
+| `workflow_for_waiting` | no | `Greengage CI` | Package generation workflow name to wait for completion |
 
 ## Usage Example
 
@@ -68,59 +52,87 @@ jobs:
       actions: read
     steps:
       - name: Upload packages to release
-        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v10
+        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v25
         with:
           version: ${{ matrix.version }}
           extensions: ${{ matrix.extensions }}
           artifact_name: ${{ matrix.artifact_name }}
 ```
 
-## How It Works: Wait for Package Building
+## How It Works
 
-The action waits for the **package generation workflow** to complete before proceeding:
+### 1. Wait for Package Generation Workflow
 
-1. **Identifies the correct workflow run** by filtering on:
-   - Commit SHA (same as current release)
-   - Event type (`push`)
-   - Branch/tag name (release tag)
+The action polls the package generation workflow (`Greengage CI` by default) and waits for completion:
 
-2. **Monitors workflow status** until:
-   - **Success**: Proceeds with cache restoration and upload
-   - **Failure**: Exits with error and link to failed run
-   - **Timeout**: Exits after specified wait time
+- Filters workflow runs by:
+  - **Commit SHA** - must match current commit
+  - **Event type** - must be `push`
+  - **Branch/tag** - must match release tag
+- Monitors status until:
+  - **Success** - proceeds with cache restoration
+  - **Failure** - exits with error and link to failed run
+  - **Timeout** - exits after `ci_wait_timeout` seconds
 
-3. **Requires specific permissions**:
-   - `contents: write` for release operations
-   - GitHub token with access to workflow run information
+### 2. Restore Artifacts from Cache
+
+Restores packages using cache key format: `{artifact_name}-{commit_sha}`
+
+If cache miss occurs, the action provides instructions to re-run the CI workflow:
+```
+ERROR: Cache missed but last build succeeded. No artifacts found for tag: '<tag>'
+Please go to <CI_WORKFLOW_URL> and click 'Re-run all jobs' to rebuild cache
+```
+
+### 3. Create Release (Optional)
+
+When `create_force` is specified, creates the release with:
+- Title: `Release <RELEASE_NAME>`
+- Notes: Package name, version, commit SHA, and workflow run number
+
+### 4. Upload Packages
+
+For each extension in `extensions`:
+1. Finds the matching file in the artifact directory
+2. Validates exactly one file exists per extension
+3. Renames to: `{PACKAGE_NAME}{VERSION}.{EXT}`
+4. Uploads to release with `gh release upload`
+5. Applies `--clobber` flag if enabled
+
+## Requirements
+
+- **Docker**: Not required
+- **Permissions**:
+  - `contents: write` - for release creation and upload
+  - `actions: read` - for workflow status checking
+- **GitHub CLI**: Available in runner environment
+- **Cache**: GitHub Actions cache must be enabled
 
 ## Error Handling
 
 | Scenario | Action | Recovery |
 |----------|--------|----------|
 | Package building workflow not found within timeout | Exit with timeout error | Check workflow name/trigger conditions |
-| Package building workflow failed | Exit with failure details | Fix build issues and restart |
-| Cache miss after successful build | Provide rebuild instructions with link to CI run | Manually trigger "Re-run all jobs" on build workflow |
+| Package building workflow failed | Exit with failure details and run URL | Fix build issues and restart |
+| Cache miss after successful build | Provide rebuild instructions with CI run URL | Click 'Re-run all jobs' on build workflow |
 | Release doesn't exist and `create_force` not set | Skip upload | Set `create_force: true` or create release manually |
+| Multiple files with same extension found | Exit with error | Ensure only one file per extension exists |
+| No files with expected extension found | Exit with error | Check build output and extensions list |
 
-## Package Building Workflow Requirements
+## Outputs
 
-For this action to work correctly, the package building workflow must:
+The action does not produce explicit outputs. Side effects include:
 
-1. **Use the same commit SHA** as the release workflow
-2. **Be triggered by push events** to the release tag
-3. **Store artifacts in cache** with key format: `{artifact_name}-{commit_sha}`
-4. **Complete successfully** before the release workflow proceeds
-
-## Technical Implementation
-
-- **GitHub CLI Filtering**: Uses `gh run list --jq` with precise filtering to find the correct workflow run
-- **Cache Key Strategy**: Commit-based keys ensure artifact consistency
-- **Package Validation**: Verifies exactly one file per extension before upload
-- **Release Metadata**: Includes build provenance in release notes
+- GitHub release created or updated
+- Packages uploaded to release
+- `CI_WORKFLOW_URL` environment variable set after successful wait
 
 ## Notes
 
 - **Workflow Names**: Ensure `workflow_for_waiting` matches the exact name of your package building workflow
 - **Permissions**: Requires `GH_TOKEN` with `actions:read` and `contents:write` scopes
-- **Concurrency**: Consider using concurrency groups to prevent race conditions between workflows
-- **Cache Expiration**: GitHub Actions cache has retention policies; consider artifact fallback for long-term storage
+- **Concurrency**: Consider using concurrency groups to prevent race conditions
+- **Package Validation**: Expects exactly one file per extension; fails if count differs
+- **Upload Failures**: If `clobber` is false and asset exists, upload is skipped for that extension
+
+For further details, refer to the action definition in `.github/actions/upload-pkgs-to-release/action.yaml`.

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Upload Debian artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: deb-packages
+          name: deb_ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}
           path: deb-packages
 
       - name: Cache Debian artifacts
@@ -86,7 +86,7 @@ jobs:
       - name: Download deb artifacts
         uses: actions/download-artifact@v4
         with:
-          name: deb-packages
+          name: deb_ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}
           path: deb-packages
       - name: Start Docker container and install deb package
         run: |
@@ -97,18 +97,3 @@ jobs:
               apt-get update && \
               { apt-get install -y /deb-packages/*.deb 2>&1 || dpkg -i /deb-packages/*.deb 2>&1; } && \
               apt-get install -f -y"
-
-  # upload-to-release:
-  #   if: startsWith(github.ref, 'refs/tags/')
-  #   needs: [build-deb, test-docker]
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: write  # Required for release creation
-  #   steps:
-  #     - name: Upload packages to release
-  #       uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v19
-  #       with:
-  #         version: ${{ inputs.version }}    # optional, defaults empty
-  #         artifact_name: deb-packages       # optional, defaults to Packages
-  #         package_name: greengage           # optional, defaults to repo name
-  #         extensions: "deb ddeb"            # optional, space-separated list of extensions

--- a/README/REUSABLE-PACKAGE.md
+++ b/README/REUSABLE-PACKAGE.md
@@ -1,6 +1,6 @@
 # Greengage Reusable Package Workflow
 
-This workflow builds and packages Debian (.deb) packages for the Greengage project and optionally tests their installation in Lima or Docker environments. It is designed to be called from a parent CI pipeline, providing flexibility for version, target operating system, and testing configurations.
+This workflow builds and packages Debian (.deb) packages for the Greengage project and optionally tests their installation in Docker environments. It is designed to be called from a parent CI pipeline, providing flexibility for version, target operating system, and testing configurations.
 
 ## Actual version
 
@@ -11,7 +11,6 @@ This workflow builds and packages Debian (.deb) packages for the Greengage proje
 The workflow performs the following tasks:
 
 - `build-deb`: Builds Debian packages for the specified Greengage version and target operating system (Ubuntu).
-- `test-lima`: Tests installation of the generated Debian packages in a Lima virtual machine (if specified).
 - `test-docker`: Tests installation of the generated Debian packages in a Docker container (if specified).
 
 ### Algorithm
@@ -22,42 +21,23 @@ The workflow processes the source code to build and test Debian packages. Below 
 
   - Checks out the repository with submodules and full history.
   - Logs into the GitHub Container Registry (GHCR) using the provided token.
-  - Builds or pulls a builder Docker image (`ghcr.io/<repo>/ggdb<version>_<target_os><target_os_version>:builder`) based on the `rebuild_builder` input:
+  - Restores builder Docker image from cache using key format: `ggdb<version>_<target_os><target_os_version>-image-${{ github.sha }}`.
+  - Runs the builder image to compile Debian packages using `make -C gpdb_src/gpAux pkg-deb`.
+  - Uploads generated artifacts as `deb_ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}`.
+  - Caches the packages directory with key: `deb-packages-${{ github.sha }}`.
 
-    - If `rebuild_builder` is `true` or the builder image does not exist, builds and pushes the image using `Dockerfile.ubuntu.builder`.
-    - Otherwise, pulls the existing builder image.
+2. **Test Installation in Docker** (`test-docker`, if `test_docker` is provided):
 
-  - Runs the builder image to compile Debian packages using `make -C gpdb_src/gpAux pkg-deb` with parallel compilation based on available CPU cores.
-
-  - Determines changelog options based on the event:
-
-    - For tagged push events (`refs/tags/*`), uses default changelog options.
-    - For branch pushes, includes all commits since the last tag (`last-tag all-commits`).
-
-  - Uploads generated artifacts (`.deb`, `.ddeb`, `.build`, `.buildinfo`, `.changes`) as `deb-packages`.
-
-2. **Test Installation in Lima** (`test-lima`, if `test_lima` is provided):
-
-  - Sets up Lima and caches its configuration.
-  - Downloads the `deb-packages` artifact.
-  - Starts a Lima VM with the specified template (e.g., `ubuntu-22.04`), configured with 4 CPUs, 8GB memory, and a 9p filesystem mount.
-  - Copies the Debian packages to the VM and installs them using `apt-get install` or `dpkg -i` with `apt-get install -f` for dependency resolution.
-  - Uploads installation logs as `install-logs`.
-  - Cleans up the Lima VM on completion or failure.
-
-3. **Test Installation in Docker** (`test-docker`, if `test_docker` is provided):
-
-  - Downloads the `deb-packages` artifact.
+  - Downloads the `deb_ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}` artifact.
   - Runs a Docker container with the specified image (e.g., `ubuntu:<target_os_version>`).
   - Installs the Debian packages using `apt-get install` or `dpkg -i` with `apt-get install -f` for dependency resolution.
-  - Uploads installation logs as `install-logs-docker`.
 
-4. **Failure Conditions**:
+3. **Failure Conditions**:
 
-  - If the builder image build or pull fails, the `build-deb` job exits with an error.
+  - If the builder image restore fails, the `build-deb` job exits with an error.
   - If `target_os` is not `ubuntu`, the `build-deb` job is skipped.
   - If the Debian package build fails (e.g., due to missing dependencies or compilation errors), the `build-deb` job exits with an error.
-  - If installation in Lima or Docker fails, the respective test job exits with an error, but subsequent jobs are not blocked.
+  - If installation in Docker fails, the test job exits with an error.
   - If `ghcr_token` is invalid or lacks permissions, GHCR login fails, causing the workflow to exit.
 
 ## Usage
@@ -76,7 +56,6 @@ Name                | Description                                          | Req
 `target_os`         | Target operating system (e.g., `ubuntu`)             | Yes      | String  | -
 `target_os_version` | Target OS version (e.g., `22.04`, `24.04`)           | Yes      | String  | -
 `rebuild_builder`   | Rebuild builder image even if it exists              | No       | Boolean | `false`
-`test_lima`         | Lima template (e.g., `ubuntu-22.04`) for deploy test | No       | String  | `''`
 `test_docker`       | Docker image (e.g., `ubuntu:22.04`) for deploy test  | No       | String  | `''`
 
 ### Secrets
@@ -109,7 +88,6 @@ Name         | Description                  | Required
         target_os: ubuntu
         target_os_version: '22.04'
         rebuild_builder: false
-        test_lima: ubuntu-22.04
         test_docker: ubuntu:22.04
       secrets:
         ghcr_token: ${{ secrets.GITHUB_TOKEN }}
@@ -146,8 +124,6 @@ Name         | Description                  | Required
 ### Notes
 
 - The `build-deb` job is skipped if `target_os` is not `ubuntu`.
-- If `test_lima` or `test_docker` is empty, the respective test job is skipped.
-- The workflow fetches full git history to support changelog generation for non-tagged commits.
-- Installation logs are uploaded for debugging failed installations.
-- Lima VMs are cleaned up after execution to avoid resource leaks.
+- If `test_docker` is empty, the test job is skipped.
+- Artifact name includes OS and version: `deb_ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}`.
 - For further details, refer to the workflow file in the `.github/workflows/` directory.


### PR DESCRIPTION
- Add OS/version to artifact name in greengage-reusable-package.yml
- Update upload-pkgs-to-release README to match actual v25 version
- Remove Lima test support from package workflow and documentation
- Update REUSABLE-PACKAGE.md with new artifact naming convention