### PR TITLE
Refactor/package workflow simplify testing

### DIFF
--- a/.github/actions/restore-load-image/README.md
+++ b/.github/actions/restore-load-image/README.md
@@ -6,7 +6,7 @@ Restores a Docker image tarball from cache (or pulls from GHCR) and loads it int
 
 ```yaml
 - name: Restore and load Docker image
-  uses: greengagedb/greengage-ci/.github/actions/restore-load-image@v26
+  uses: greengagedb/greengage-ci/.github/actions/restore-load-image@refactor/package-workflow-simplify
   with:
     version: '6' # or '7'
     target_os: 'ubuntu'
@@ -17,7 +17,7 @@ Restores a Docker image tarball from cache (or pulls from GHCR) and loads it int
 
 ## Actual version
 
-- `greengagedb/greengage-ci/.github/actions/restore-load-image/action.yml@v26`
+- `greengagedb/greengage-ci/.github/actions/restore-load-image/action.yml@refactor/package-workflow-simplify`
 
 ## Inputs
 

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -20,16 +20,6 @@ on:
         required: false
         type: boolean
         default: false
-      test_lima:
-        description: 'Lima Template (e.g., ubuntu-22.04) for deploy test. Skip if empty'
-        required: false
-        type: string
-        default: ''
-      test_docker:
-        description: 'Docker Image (e.g., ubuntu:22.04, ubuntu:noble) for deploy test. Skip if empty'
-        required: false
-        type: string
-        default: ''
     secrets:
       ghcr_token:
         description: 'GitHub token for GHCR access'
@@ -76,10 +66,9 @@ jobs:
           path: deb-packages
           key: deb-packages-${{ github.sha }}
 
-  test-docker:
-    if: inputs.test_docker != ''
+  test-install:
     env:
-      TEST_DOCKER: ${{ inputs.test_docker }}
+      TARGET_IMAGE: ${{ inputs.target_os }}:${{ inputs.target_os_version }}
     needs: build-deb
     runs-on: ubuntu-latest
     steps:
@@ -88,27 +77,12 @@ jobs:
         with:
           name: deb-packages
           path: deb-packages
-      - name: Start Docker container and install deb package
+      - name: Install deb package in container
         run: |
           set -eux
           docker run --rm -v ./deb-packages:/deb-packages \
-            "${TEST_DOCKER}" /bin/bash -c "\
+            "${TARGET_IMAGE}" /bin/bash -c "\
               export DEBIAN_FRONTEND=noninteractive && \
               apt-get update && \
               { apt-get install -y /deb-packages/*.deb 2>&1 || dpkg -i /deb-packages/*.deb 2>&1; } && \
               apt-get install -f -y"
-
-  # upload-to-release:
-  #   if: startsWith(github.ref, 'refs/tags/')
-  #   needs: [build-deb, test-docker]
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: write  # Required for release creation
-  #   steps:
-  #     - name: Upload packages to release
-  #       uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v19
-  #       with:
-  #         version: ${{ inputs.version }}    # optional, defaults empty
-  #         artifact_name: deb-packages       # optional, defaults to Packages
-  #         package_name: greengage           # optional, defaults to repo name
-  #         extensions: "deb ddeb"            # optional, space-separated list of extensions

--- a/.github/workflows/greengage-reusable-tests-resgroup.yml
+++ b/.github/workflows/greengage-reusable-tests-resgroup.yml
@@ -60,7 +60,7 @@ jobs:
             https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
 
       - name: Restore & Load SHA image
-        uses: greengagedb/greengage-ci/.github/actions/restore-load-image@v26
+        uses: greengagedb/greengage-ci/.github/actions/restore-load-image@refactor/package-workflow-simplify
         with:
           version: ${{ inputs.version }}
           target_os: ${{ inputs.target_os }}

--- a/README/REUSABLE-PACKAGE.md
+++ b/README/REUSABLE-PACKAGE.md
@@ -1,18 +1,17 @@
 # Greengage Reusable Package Workflow
 
-This workflow builds and packages Debian (.deb) packages for the Greengage project and optionally tests their installation in Lima or Docker environments. It is designed to be called from a parent CI pipeline, providing flexibility for version, target operating system, and testing configurations.
+This workflow builds and packages Debian (.deb) packages for the Greengage project and tests their installation in a Docker container. It is designed to be called from a parent CI pipeline, providing flexibility for version and target operating system.
 
 ## Actual version
 
-- `greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v25`
+- `greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v27`
 
 ## Purpose
 
 The workflow performs the following tasks:
 
 - `build-deb`: Builds Debian packages for the specified Greengage version and target operating system (Ubuntu).
-- `test-lima`: Tests installation of the generated Debian packages in a Lima virtual machine (if specified).
-- `test-docker`: Tests installation of the generated Debian packages in a Docker container (if specified).
+- `test-install`: Tests installation of the generated Debian packages in a Docker container (mandatory).
 
 ### Algorithm
 
@@ -20,45 +19,25 @@ The workflow processes the source code to build and test Debian packages. Below 
 
 1. **Build Debian Packages** (`build-deb`):
 
-  - Checks out the repository with submodules and full history.
-  - Logs into the GitHub Container Registry (GHCR) using the provided token.
-  - Builds or pulls a builder Docker image (`ghcr.io/<repo>/ggdb<version>_<target_os><target_os_version>:builder`) based on the `rebuild_builder` input:
+- Checks out the repository with submodules and full history.
+- Logs into the GitHub Container Registry (GHCR) using the provided token.
+- Restores or loads the SHA image using `restore-load-image` action.
+- Runs the builder image to compile Debian packages using `make -C gpdb_src/gpAux pkg-deb`.
+- Uploads and caches generated artifacts (`.deb` packages) as `deb-packages`.
 
-    - If `rebuild_builder` is `true` or the builder image does not exist, builds and pushes the image using `Dockerfile.ubuntu.builder`.
-    - Otherwise, pulls the existing builder image.
+1. **Test Installation in Docker** (`test-install`):
 
-  - Runs the builder image to compile Debian packages using `make -C gpdb_src/gpAux pkg-deb` with parallel compilation based on available CPU cores.
+- Downloads the `deb-packages` artifact.
+- Runs a Docker container with the target OS image derived from `target_os` and `target_os_version` inputs (e.g., `ubuntu:22.04`).
+- Installs the Debian packages using `apt-get install` or `dpkg -i` with `apt-get install -f` for dependency resolution.
 
-  - Determines changelog options based on the event:
+1. **Failure Conditions**:
 
-    - For tagged push events (`refs/tags/*`), uses default changelog options.
-    - For branch pushes, includes all commits since the last tag (`last-tag all-commits`).
-
-  - Uploads generated artifacts (`.deb`, `.ddeb`, `.build`, `.buildinfo`, `.changes`) as `deb-packages`.
-
-2. **Test Installation in Lima** (`test-lima`, if `test_lima` is provided):
-
-  - Sets up Lima and caches its configuration.
-  - Downloads the `deb-packages` artifact.
-  - Starts a Lima VM with the specified template (e.g., `ubuntu-22.04`), configured with 4 CPUs, 8GB memory, and a 9p filesystem mount.
-  - Copies the Debian packages to the VM and installs them using `apt-get install` or `dpkg -i` with `apt-get install -f` for dependency resolution.
-  - Uploads installation logs as `install-logs`.
-  - Cleans up the Lima VM on completion or failure.
-
-3. **Test Installation in Docker** (`test-docker`, if `test_docker` is provided):
-
-  - Downloads the `deb-packages` artifact.
-  - Runs a Docker container with the specified image (e.g., `ubuntu:<target_os_version>`).
-  - Installs the Debian packages using `apt-get install` or `dpkg -i` with `apt-get install -f` for dependency resolution.
-  - Uploads installation logs as `install-logs-docker`.
-
-4. **Failure Conditions**:
-
-  - If the builder image build or pull fails, the `build-deb` job exits with an error.
-  - If `target_os` is not `ubuntu`, the `build-deb` job is skipped.
-  - If the Debian package build fails (e.g., due to missing dependencies or compilation errors), the `build-deb` job exits with an error.
-  - If installation in Lima or Docker fails, the respective test job exits with an error, but subsequent jobs are not blocked.
-  - If `ghcr_token` is invalid or lacks permissions, GHCR login fails, causing the workflow to exit.
+- If the builder image build or pull fails, the `build-deb` job exits with an error.
+- If `target_os` is not `ubuntu`, the `build-deb` job is skipped.
+- If the Debian package build fails (e.g., due to missing dependencies or compilation errors), the `build-deb` job exits with an error.
+- If installation in Docker fails, the `test-install` job exits with an error.
+- If `ghcr_token` is invalid or lacks permissions, GHCR login fails, causing the workflow to exit.
 
 ## Usage
 
@@ -76,8 +55,6 @@ Name                | Description                                          | Req
 `target_os`         | Target operating system (e.g., `ubuntu`)             | Yes      | String  | -
 `target_os_version` | Target OS version (e.g., `22.04`, `24.04`)           | Yes      | String  | -
 `rebuild_builder`   | Rebuild builder image even if it exists              | No       | Boolean | `false`
-`test_lima`         | Lima template (e.g., `ubuntu-22.04`) for deploy test | No       | String  | `''`
-`test_docker`       | Docker image (e.g., `ubuntu:22.04`) for deploy test  | No       | String  | `''`
 
 ### Secrets
 
@@ -103,14 +80,12 @@ Name         | Description                  | Required
         contents: read
         packages: write
         actions: write
-      uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v25
+      uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v27
       with:
         version: 6
         target_os: ubuntu
         target_os_version: '22.04'
         rebuild_builder: false
-        test_lima: ubuntu-22.04
-        test_docker: ubuntu:22.04
       secrets:
         ghcr_token: ${{ secrets.GITHUB_TOKEN }}
   ```
@@ -132,13 +107,12 @@ Name         | Description                  | Required
         contents: read
         packages: write
         actions: write
-      uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v25
+      uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v27
       with:
         version: 6
         target_os: ${{ matrix.target_os }}
         target_os_version: ${{ matrix.target_os_version }}
         rebuild_builder: false
-        test_docker: ubuntu:${{ matrix.target_os_version }}
       secrets:
         ghcr_token: ${{ secrets.GITHUB_TOKEN }}
   ```
@@ -146,8 +120,7 @@ Name         | Description                  | Required
 ### Notes
 
 - The `build-deb` job is skipped if `target_os` is not `ubuntu`.
-- If `test_lima` or `test_docker` is empty, the respective test job is skipped.
+- The `test-install` job always runs after `build-deb` (mandatory).
+- The target Docker image for testing is automatically derived from `target_os` and `target_os_version` inputs.
 - The workflow fetches full git history to support changelog generation for non-tagged commits.
-- Installation logs are uploaded for debugging failed installations.
-- Lima VMs are cleaned up after execution to avoid resource leaks.
 - For further details, refer to the workflow file in the `.github/workflows/` directory.

--- a/README/REUSABLE-PACKAGE.md
+++ b/README/REUSABLE-PACKAGE.md
@@ -75,8 +75,6 @@ To integrate this workflow into your pipeline:
 | `target_os`         | Target operating system (e.g., `ubuntu`)             | Yes      | String  | -       |
 | `target_os_version` | Target OS version (e.g., ``, `24.04`)                | No       | String  | `''`    |
 | `rebuild_builder`   | Rebuild builder image even if it exists              | No       | Boolean | `false` |
-| `test_lima`         | Lima template (e.g., `ubuntu-22.04`) for deploy test | No       | String  | `''`    |
-| `test_docker`       | Docker image (e.g., `ubuntu:22.04`) for deploy test  | No       | String  | `''`    |
 
 ### Secrets
 


### PR DESCRIPTION
* Remove optional test_lima and test_docker inputs
  - Docker installation test is now mandatory, no conditional execution

* Derive target Docker image from inputs automatically
  - TARGET_IMAGE computed from target_os and target_os_version
  - No need to pass test_docker explicitly

* Rename TEST_DOCKER to TARGET_IMAGE
  - More accurate name reflecting it stores OS image reference

* Rename test step to "Install deb package in container"
  - Clearer description of the step's purpose

* Update REUSABLE-PACKAGE.md documentation
  - Remove Lima test references and optional test inputs
  - Document mandatory Docker test behavior
  - Update examples to remove test_lima/test_docker parameters
  - Simplify algorithm description to match current workflow structure