### PR TITLE
CI-5427: Use conventional filenames for deb-packages in the Release

### DIFF
--- a/.github/actions/upload-pkgs-to-release/README.md
+++ b/.github/actions/upload-pkgs-to-release/README.md
@@ -19,18 +19,16 @@ This composite GitHub Action orchestrates the package release process by coordin
    - Creates GitHub release when `create_force` is specified and release doesn't exist
    - Includes build metadata (commit SHA, workflow run ID) in release notes
 
-4. **Upload Packages with Standardized Names**
-   - Renames packages to fixed pattern: `${PACKAGE_NAME}${VERSION}.${EXT}`
-   - Uploads to release with optional overwrite (`clobber` flag)
+4. **Upload Packages with Original Names**
+   - Uploads packages to release preserving their original filenames
+   - Optional overwrite with `clobber` flag
 
 ## Inputs
 
 | Name | Required | Default | Description |
-|------|----------|---------|-------------|
+| ---- | -------- | ------- | ----------- |
 | `artifact_name` | no | `Packages` | Cache key prefix for artifact restoration |
-| `package_name` | no | repo name | Base package name for uploaded files |
 | `release_name` | no | current tag | Target release name (defaults to tag) |
-| `version` | no | empty | Version suffix for package names |
 | `extensions` | no | `deb ddeb rpm` | Space-separated package extensions |
 | `create_force` | no | empty | Force release creation if missing |
 | `clobber` | no | `false` | Overwrite existing release assets |
@@ -59,9 +57,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - version: 6
-          extensions: deb ddeb
+        - extensions: deb ddeb
           artifact_name: deb-packages
+        - extensions: rpm
+          artifact_name: rpm-packages
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -70,7 +69,6 @@ jobs:
       - name: Upload packages to release
         uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v10
         with:
-          version: ${{ matrix.version }}
           extensions: ${{ matrix.extensions }}
           artifact_name: ${{ matrix.artifact_name }}
 ```
@@ -96,7 +94,7 @@ The action waits for the **package generation workflow** to complete before proc
 ## Error Handling
 
 | Scenario | Action | Recovery |
-|----------|--------|----------|
+| -------- | ------ | -------- |
 | Package building workflow not found within timeout | Exit with timeout error | Check workflow name/trigger conditions |
 | Package building workflow failed | Exit with failure details | Fix build issues and restart |
 | Cache miss after successful build | Provide rebuild instructions with link to CI run | Manually trigger "Re-run all jobs" on build workflow |
@@ -116,6 +114,7 @@ For this action to work correctly, the package building workflow must:
 - **GitHub CLI Filtering**: Uses `gh run list --jq` with precise filtering to find the correct workflow run
 - **Cache Key Strategy**: Commit-based keys ensure artifact consistency
 - **Package Validation**: Verifies exactly one file per extension before upload
+- **Original Filename Preservation**: Files are uploaded with their original names from the artifact
 - **Release Metadata**: Includes build provenance in release notes
 
 ## Notes

--- a/.github/actions/upload-pkgs-to-release/README.md
+++ b/.github/actions/upload-pkgs-to-release/README.md
@@ -57,10 +57,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - extensions: deb ddeb
-          artifact_name: deb-packages
-        - extensions: rpm
-          artifact_name: rpm-packages
+        - artifact_name: deb-packages
+          extensions:    deb ddeb
+        - artifact_name: rpm-packages
+          extensions:    rpm ddeb
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/actions/upload-pkgs-to-release/action.yaml
+++ b/.github/actions/upload-pkgs-to-release/action.yaml
@@ -177,26 +177,22 @@ runs:
           echo "Release '$RELEASE_NAME' not found, skipping upload"
         fi
 
-    - name: Move and upload packages
+    - name: Upload packages
       if: steps.check_release.outputs.exists == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
         RELEASE_NAME: ${{ inputs.release_name }}
-        PACKAGE_NAME: ${{ inputs.package_name }}
       run: |
-        PACKAGE_NAME=${PACKAGE_NAME:-${GITHUB_REPOSITORY#*/}}
         RELEASE_NAME=${RELEASE_NAME:-${GITHUB_REF#refs/tags/}}
 
-        for var in PACKAGE_NAME RELEASE_NAME ; do
-          if [ -z "${!var}" ] ; then
-            echo "Can't determine $var"
-            exit 1
-          fi
-        done
+        if [ -z "$RELEASE_NAME" ] ; then
+          echo "Can't determine RELEASE_NAME"
+          exit 1
+        fi
 
         shopt -s nullglob
-        
+
         for ext in ${{ inputs.extensions }}; do
           files=("${{ inputs.artifact_name }}"/*.$ext)
           if [ ${#files[@]} -ne 1 ]; then
@@ -204,10 +200,8 @@ runs:
             exit 1
           fi
 
-          target="${{ inputs.artifact_name }}/${PACKAGE_NAME}${{ inputs.version }}.$ext"
-          mv -f "${files[0]}" "$target"
-          echo "Uploading $target"
-          gh release upload "$RELEASE_NAME" "$target" ${{ inputs.clobber == 'true' && '--clobber' || '' }} || not_uploaded=${not_uploaded:+$not_uploaded, }$ext
+          echo "Uploading ${files[0]}"
+          gh release upload "$RELEASE_NAME" "${files[0]}" ${{ inputs.clobber == 'true' && '--clobber' || '' }} || not_uploaded=${not_uploaded:+$not_uploaded, }$ext
         done
         if [ -n "$not_uploaded" ] ; then
           echo "The following extension(s) are not uploaded: $not_uploaded"


### PR DESCRIPTION
## Use conventional filenames for deb-packages in the Release (#40)

[refactor(upload-pkgs-to-release): preserve original filenames on upload](https://github.com/GreengageDB/greengage-ci/commit/fffdfe0c9731347953b8c418bf0aa42b08239a8e)

- Remove package renaming step, upload files with original names
- Remove unused `package_name` and `version` inputs
- Update README to reflect original filename preservation
- Update usage example with RPM packages in matrix

Task: [CI-5427](https://tracker.yandex.ru/CI-5427)