### PR TITLE
CI-5460 Replace ubuntu-latest runners with ubuntu-24.04

### DIFF
--- a/.github/actions/restore-load-image/action.yml
+++ b/.github/actions/restore-load-image/action.yml
@@ -25,7 +25,10 @@ runs:
       id: pull
       env:
         IMAGE: ghcr.io/${{ github.repository }}/ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}:${{ github.sha }}
-      run: docker pull ${IMAGE,,}
+        SAVE_TAR: ${{ inputs.save_tar }}
+      run: |
+        docker pull ${IMAGE,,}
+        [ -n "$SAVE_TAR" ] && docker save -o ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}_${{ github.sha }}.tar ${IMAGE,,}
 
     - name: Restore SHA image from cache
       if: steps.pull.outcome == 'failure'

--- a/.github/actions/upload-pkgs-to-release/README.md
+++ b/.github/actions/upload-pkgs-to-release/README.md
@@ -7,34 +7,38 @@ This composite GitHub Action orchestrates the package release process by coordin
 ### Sequence of Operations
 
 1. **Wait for Package Building Workflow Completion**
-   - Polls the specified package generation workflow (`Greengage CI` by default)
-   - Verifies the workflow completed successfully for the exact commit and tag
-   - Provides configurable timeout (default: 4 hours) and polling interval (default: 60 seconds)
+
+  - Polls the specified package generation workflow (`Greengage CI` by default)
+  - Verifies the workflow completed successfully for the exact commit and tag
+  - Provides configurable timeout (default: 4 hours) and polling interval (default: 60 seconds)
 
 2. **Restore Built Packages from Cache**
-   - Retrieves packages from GitHub Actions cache using commit SHA as key
-   - Cache key format: `{artifact_name}-{commit_sha}`
+
+  - Retrieves packages from GitHub Actions cache using commit SHA as key
+  - Cache key format: `{artifact_name}-{commit_sha}`
 
 3. **Create Release if Needed**
-   - Creates GitHub release when `create_force` is specified and release doesn't exist
-   - Includes build metadata (commit SHA, workflow run ID) in release notes
+
+  - Creates GitHub release when `create_force` is specified and release doesn't exist
+  - Includes build metadata (commit SHA, workflow run ID) in release notes
 
 4. **Upload Packages with Original Names**
-   - Uploads packages to release preserving their original filenames
-   - Optional overwrite with `clobber` flag
+
+  - Uploads packages to release preserving their original filenames
+  - Optional overwrite with `clobber` flag
 
 ## Inputs
 
-| Name | Required | Default | Description |
-| ---- | -------- | ------- | ----------- |
-| `artifact_name` | no | `Packages` | Cache key prefix for artifact restoration |
-| `release_name` | no | current tag | Target release name (defaults to tag) |
-| `extensions` | no | `deb ddeb rpm` | Space-separated package extensions |
-| `create_force` | no | empty | Force release creation if missing |
-| `clobber` | no | `false` | Overwrite existing release assets |
-| `ci_wait_timeout` | no | `14400` | Timeout in seconds to wait for CI workflow (4 hours) |
-| `ci_poll_interval` | no | `60` | Poll interval in seconds to check CI workflow status |
-| `workflow_for_waiting` | no | `Greengage CI` | **Name of the package building workflow** to wait for completion |
+Name                   | Required | Default        | Description
+---------------------- | -------- | -------------- | ----------------------------------------------------------------
+`artifact_name`        | no       | `Packages`     | Cache key prefix for artifact restoration
+`release_name`         | no       | current tag    | Target release name (defaults to tag)
+`extensions`           | no       | `deb ddeb rpm` | Space-separated package extensions
+`create_force`         | no       | empty          | Force release creation if missing
+`clobber`              | no       | `false`        | Overwrite existing release assets
+`ci_wait_timeout`      | no       | `14400`        | Timeout in seconds to wait for CI workflow (4 hours)
+`ci_poll_interval`     | no       | `60`           | Poll interval in seconds to check CI workflow status
+`workflow_for_waiting` | no       | `Greengage CI` | **Name of the package building workflow** to wait for completion
 
 ## Key Features
 
@@ -61,7 +65,7 @@ jobs:
           extensions:    deb ddeb
         - artifact_name: rpm-packages
           extensions:    rpm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       actions: read
@@ -78,27 +82,30 @@ jobs:
 The action waits for the **package generation workflow** to complete before proceeding:
 
 1. **Identifies the correct workflow run** by filtering on:
-   - Commit SHA (same as current release)
-   - Event type (`push`)
-   - Branch/tag name (release tag)
+
+  - Commit SHA (same as current release)
+  - Event type (`push`)
+  - Branch/tag name (release tag)
 
 2. **Monitors workflow status** until:
-   - **Success**: Proceeds with cache restoration and upload
-   - **Failure**: Exits with error and link to failed run
-   - **Timeout**: Exits after specified wait time
+
+  - **Success**: Proceeds with cache restoration and upload
+  - **Failure**: Exits with error and link to failed run
+  - **Timeout**: Exits after specified wait time
 
 3. **Requires specific permissions**:
-   - `contents: write` for release operations
-   - GitHub token with access to workflow run information
+
+  - `contents: write` for release operations
+  - GitHub token with access to workflow run information
 
 ## Error Handling
 
-| Scenario | Action | Recovery |
-| -------- | ------ | -------- |
-| Package building workflow not found within timeout | Exit with timeout error | Check workflow name/trigger conditions |
-| Package building workflow failed | Exit with failure details | Fix build issues and restart |
-| Cache miss after successful build | Provide rebuild instructions with link to CI run | Manually trigger "Re-run all jobs" on build workflow |
-| Release doesn't exist and `create_force` not set | Skip upload | Set `create_force: true` or create release manually |
+Scenario                                           | Action                                           | Recovery
+-------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------
+Package building workflow not found within timeout | Exit with timeout error                          | Check workflow name/trigger conditions
+Package building workflow failed                   | Exit with failure details                        | Fix build issues and restart
+Cache miss after successful build                  | Provide rebuild instructions with link to CI run | Manually trigger "Re-run all jobs" on build workflow
+Release doesn't exist and `create_force` not set   | Skip upload                                      | Set `create_force: true` or create release manually
 
 ## Package Building Workflow Requirements
 

--- a/.github/workflows/greengage-reusable-build.yml
+++ b/.github/workflows/greengage-reusable-build.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read  # Explicit for default behavior
       packages: write # Required to push to GHCR

--- a/.github/workflows/greengage-reusable-cleanup.yml
+++ b/.github/workflows/greengage-reusable-cleanup.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Set up crane
         uses: imjasonh/setup-crane@v0.3

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -13,7 +13,7 @@ on:
         type: string
       target_os_version:
         description: 'Target OS version (e.g., 22.04, 24.04)'
-        required: true
+        required: false
         type: string
       rebuild_builder:
         description: 'Rebuild builder image required'
@@ -38,7 +38,7 @@ on:
 jobs:
   build-deb:
     if: inputs.target_os == 'ubuntu'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -81,7 +81,7 @@ jobs:
     env:
       TEST_DOCKER: ${{ inputs.test_docker }}
     needs: build-deb
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Download deb artifacts
         uses: actions/download-artifact@v4
@@ -101,7 +101,7 @@ jobs:
   # upload-to-release:
   #   if: startsWith(github.ref, 'refs/tags/')
   #   needs: [build-deb, test-docker]
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-24.04
   #   permissions:
   #     contents: write  # Required for release creation
   #   steps:

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   generate-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       feature_matrix: ${{ steps.set-matrix.outputs.feature_matrix }}
     steps:
@@ -53,7 +53,7 @@ jobs:
 
   behave:
     needs: generate-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -143,7 +143,7 @@ jobs:
   collect-results:
     needs: behave
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity

--- a/.github/workflows/greengage-reusable-tests-jit.yml
+++ b/.github/workflows/greengage-reusable-tests-jit.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   optimizer:  # JIT tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 180
     strategy:
       fail-fast: false

--- a/.github/workflows/greengage-reusable-tests-orca.yml
+++ b/.github/workflows/greengage-reusable-tests-orca.yml
@@ -19,7 +19,7 @@ on:
         type: string
       target_os_version:
         description: 'Target OS version (e.g., 22.04, 24.04)'
-        required: true
+        required: false
         type: string
       python3:
         description: 'Python3 build argument (ignored)'
@@ -33,7 +33,7 @@ on:
 
 jobs:
   orca:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read  # Explicit for default behavior
       actions: write  # Required for cache and artifact upload

--- a/.github/workflows/greengage-reusable-tests-regression.yml
+++ b/.github/workflows/greengage-reusable-tests-regression.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   optimizer:  # Regression tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 180
     strategy:
       fail-fast: false

--- a/.github/workflows/greengage-reusable-tests-resgroup.yml
+++ b/.github/workflows/greengage-reusable-tests-resgroup.yml
@@ -15,7 +15,7 @@ on:
         type: string
       target_os_version:
         description: 'Target OS version (e.g., 22.04, 24.04)'
-        required: true
+        required: false
         type: string
       python3:
         description: 'Python3 build argument (ignored)'
@@ -29,7 +29,7 @@ on:
 
 jobs:
   optimizer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -60,7 +60,7 @@ jobs:
             https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
 
       - name: Restore & Load SHA image
-        uses: greengagedb/greengage-ci/.github/actions/restore-load-image@v25
+        uses: greengagedb/greengage-ci/.github/actions/restore-load-image@v28
         with:
           version: ${{ inputs.version }}
           target_os: ${{ inputs.target_os }}

--- a/.github/workflows/greengage-reusable-upload.yml
+++ b/.github/workflows/greengage-reusable-upload.yml
@@ -14,7 +14,7 @@ on:
         type: string
       target_os_version:
         description: 'Target OS version (e.g., 22.04, 24.04)'
-        required: true
+        required: false
         type: string
       python3:
         description: 'Python3 build argument'
@@ -36,7 +36,7 @@ on:
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read  # Explicit for default behavior
       packages: write # Required to push to GHCR

--- a/examples/greengage-release.yml
+++ b/examples/greengage-release.yml
@@ -14,7 +14,7 @@ jobs:
         - version: 6
           extensions: deb ddeb
           artifact_name: deb-packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       actions: read

--- a/examples/greengage-sql-dump.yml
+++ b/examples/greengage-sql-dump.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   create-sql-dump-regression:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 180
     if: |
       github.event.workflow_run.event == 'push' &&
@@ -100,7 +100,7 @@ jobs:
           EOF
 
   verify-dumps-created:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: create-sql-dump-regression
     if: always()
     steps:


### PR DESCRIPTION
Github will introduce new ubuntu-latest with ubuntu 26.04 version.
So there could be errors in pipelines with new version.
It is needed to define a fixed tag 24.04 for all GG actions.

Task: CI-5460