### PR TITLE
GG-180 Split resgroup tests steps

### DIFF
--- a/.github/actions/collect-logs/action.yml
+++ b/.github/actions/collect-logs/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'Prefix for logs directory'
     default: 'ggdb_test'
     required: false
+  docker_host:
+    description: 'Docker host string (e.g., ssh://qemu-vm)'
+    default: ''
+    required: false
   params:
     description: 'Params for find util'
     required: false
@@ -30,6 +34,7 @@ runs:
         LOG_DIR: ${{ inputs.log_dir }}
         LOG_PATH_PREFIX: ${{ inputs.log_path_prefix }}
         PARAMS: ${{ inputs.params }}
+        DOCKER_HOST: ${{ inputs.docker_host }}
       run: |
         set -euo pipefail
 

--- a/.github/workflows/greengage-reusable-tests-resgroup.yml
+++ b/.github/workflows/greengage-reusable-tests-resgroup.yml
@@ -44,13 +44,14 @@ jobs:
       IMAGE_SHA: ${{ github.sha }}
       TEST_OS: ${{ inputs.target_os }}
       STATEMENT_MEM: ${{ inputs.version == '7' && '125MB' || '250MB' }}
+      SSH_COMMAND: "ssh qemu-vm"
 
     steps:
       - name: Setup QEMU
         run: |
           set -eux
           sudo apt update
-          sudo DEBIAN_FRONTEND=noninteractive apt install -y qemu-kvm qemu-utils cloud-image-utils libguestfs-tools
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y qemu-kvm qemu-utils cloud-image-utils libguestfs-tools openssh-client
 
       - name: Download Ubuntu cloud image
         if: steps.cache-qemu.outputs.cache-hit != 'true'
@@ -67,25 +68,34 @@ jobs:
           target_os_version: ${{ inputs.target_os_version }}
           save_tar: "true"
 
-      - name: Create cloud-init script
+      - name: Create env file
         env:
           OPTIMIZER:  ${{ matrix.optimizer == 'orca' && 'on' || 'off' }}
           IMAGE_FILE: ${{ env.IMAGE_NAME }}_${{ env.IMAGE_SHA }}.tar
         run: |
-          set -eux
-          mkdir -p vm-home
+          mkdir vm-home
 
-          cat > vm-home/cloud-init <<EOF0
+          export IMAGE=${IMAGE_REPO,,}/${IMAGE_NAME}:${IMAGE_SHA}
+
+          cat > vm-home/.env.tests <<EOF
+          CI=true
+          TEST_OS=$TEST_OS
+          OPTIMIZER=$OPTIMIZER
+          STATEMENT_MEM=$STATEMENT_MEM
+          IMAGE=$IMAGE
+          IMAGE_FILE=$IMAGE_FILE
+          DOCKER_API_VERSION=1.41
+          EOF
+
+      - name: Create cloud-init script
+        run: |
+          set -eux
+
+          cat > vm-home/cloud-init <<'EOF0'
           # cloud-init setup script
           set -e
 
-          export TEST_OS=${TEST_OS}
-          export OPTIMIZER=${OPTIMIZER}
-          export STATEMENT_MEM=${STATEMENT_MEM}
-          export IMAGE=${IMAGE_REPO,,}/${IMAGE_NAME}:${IMAGE_SHA}
-
-          # Force Docker client API version
-          export DOCKER_API_VERSION=1.41
+          source /home/gpadmin/.env.tests
 
           curl -fsSL https://get.docker.com -o get-docker.sh
           sh get-docker.sh --version 20.10
@@ -94,16 +104,16 @@ jobs:
           cd /home/gpadmin
           mkdir -p logs
 
-          docker load < ${IMAGE_FILE}
-          rm ${IMAGE_FILE}
+          docker load < $IMAGE_FILE
+          rm $IMAGE_FILE
 
           # Extract test script from Image instaed of GIT
-          docker create --name temp-container \$IMAGE
+          docker create --name temp-container $IMAGE
           docker cp temp-container:/home/gpadmin/gpdb_src/ci ./ci
           docker rm temp-container
-
-          source ci/scripts/run_resgroup_test.bash
           EOF0
+
+          cat vm-home/cloud-init
 
       - name: Create VM disk and cloud-init config
         env:
@@ -132,18 +142,31 @@ jobs:
 
           qemu-img resize vm-disk.qcow2 20G
 
+          ssh-keygen -t rsa -f id_rsa -q -N ""
+
           # Create cloud-init user-data
           cat > user-data <<EOF1
           #cloud-config
+          packages:
+            - openssh-server
           users:
             - name: gpadmin
               sudo: ALL=(ALL) NOPASSWD:ALL
               shell: /bin/bash
               uid: $UID
+            - name: root
+              ssh_authorized_keys:
+                - $(cat id_rsa.pub)
           runcmd:
+            - systemctl enable --now ssh
+            - cp -r /home/gpadmin/.ssh /tmp/ssh_backup
             - mount -t 9p -o trans=virtio,version=9p2000.L,rw hostshare /home/gpadmin
+            - cp -r /tmp/ssh_backup/. /home/gpadmin/.ssh
+            - cp ../vm-home/.env.tests /home/gpadmin/.env.tests
+            - chown -R gpadmin:gpadmin /home/gpadmin
+            - chmod 700 /home/gpadmin/.ssh
+            - chmod 600 /home/gpadmin/.ssh/authorized_keys
             - bash /home/gpadmin/cloud-init
-            - shutdown -h now
           EOF1
 
           # Create meta-data
@@ -165,7 +188,7 @@ jobs:
             -pidfile qemu.pid \
             -drive file=vm-disk.qcow2,format=qcow2,if=virtio \
             -drive file=seed.img,format=raw,if=virtio \
-            -netdev user,id=net0 \
+            -netdev user,id=net0,hostfwd=tcp::2222-:22 \
             -device virtio-net-pci,netdev=net0 \
             -fsdev local,security_model=passthrough,id=fsdev0,path=../vm-home \
             -device virtio-9p-pci,id=fs0,fsdev=fsdev0,mount_tag=hostshare \
@@ -173,9 +196,47 @@ jobs:
             -initrd initrd \
             -append "root=/dev/vda1 ro console=tty1 console=ttyS0 systemd.unified_cgroup_hierarchy=0" \
             -display none \
-            -serial stdio
-          exit_code=$(cat ../vm-home/logs/.exitcode)
-          exit ${exit_code:-255} # unknown or absent exit code is error
+            -serial stdio &
+
+      - name: Configure SSH
+        if: always()
+        run: |
+          mkdir -p ~/.ssh
+          cat >> ~/.ssh/config <<EOF
+          Host qemu-vm
+            HostName 127.0.0.1
+            Port 2222
+            User root
+            IdentityFile ${GITHUB_WORKSPACE}/vm-work/id_rsa
+            StrictHostKeyChecking no
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Wait for QEMU VM SSH and cloud-init are ready
+        run: |
+          timeout 360 bash -c '
+            until ssh -q qemu-vm exit; do
+              echo "Waiting for SSH (qemu-vm) to become available..."
+              sleep 5
+            done
+          '
+          EXIT_CODE=0
+          ${SSH_COMMAND} "echo 'Waiting for cloud-init to be done...' && sudo cloud-init status --wait" || EXIT_CODE=$?
+          if [[ "$EXIT_CODE" > 1 ]]; then echo "cloud-init status check has some warnings!"; exit $EXIT_CODE; fi
+
+      - name: Run resgorup tests
+        run: |
+          ${SSH_COMMAND} "cd /home/gpadmin \
+                          && export \$(cat .env.tests | xargs) \
+                          && bash ci/scripts/run_resgroup_test.bash"
+
+      - name: Collect logs
+        if: always()
+        uses: greengagedb/greengage-ci/.github/actions/collect-logs@v29
+        with:
+          log_dir: '/logs'
+          log_path_prefix: 'ggdb_test'
+          docker_host: 'ssh://qemu-vm'
 
       - name: Normalize permissions
         if: always()

--- a/README/REUSABLE-TESTS-RESGROUP.md
+++ b/README/REUSABLE-TESTS-RESGROUP.md
@@ -4,7 +4,7 @@ This workflow runs resource groups test suites for the Greengage project using Q
 
 ## Actual version
 
-- `greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v25`
+- `greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v29`
 
 ## Purpose
 
@@ -90,7 +90,7 @@ jobs:
         contents: read
         packages: read
         actions: write
-      uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-resgroup-tests.yml@v25
+      uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-resgroup-tests.yml@v29
       with:
         version: 7
         target_os: ubuntu
@@ -116,7 +116,7 @@ jobs:
         contents: read
         packages: read
         actions: write
-      uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-resgroup-tests.yml@v25
+      uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-resgroup-tests.yml@v29
       with:
         version: 7
         target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## Bump resgroup workflow version

### Problem

Previously, when resgroup tests were cancelled, logs were not always collected
and uploaded as artifacts. This made debugging failures difficult.

### Solution

#### Start the QEMU VM

Initialize and boot the QEMU virtual machine.

#### Run tests via SSH

Connect to the QEMU VM via SSH and run tests.

#### Collect logs (separate step)

This step runs regardless of test outcome (`always()`), ensuring logs are
preserved.

### Implementation details

Log collection is decoupled from test execution.

SSH configuration is prepared to enable interaction with Docker running inside
the QEMU VM:

- `DOCKER_HOST=ssh://qemu-vm` variable is used to run Docker commands
directly on the VM.

Task: GG-180