### PR TITLE
GG-162: Don't use actions cache if developer's image is present in GHCR

### DIFF
--- a/.github/workflows/greengage-reusable-build.yml
+++ b/.github/workflows/greengage-reusable-build.yml
@@ -77,19 +77,9 @@ jobs:
             -f ci/Dockerfile.${{ inputs.target_os }}
             .
 
-      # Save Docker image
-      - name: Save SHA image
-        run: docker save ${IMAGE,,}:${{ github.sha }} > ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}_${{ github.sha }}.tar
-
-      # Cache SHA image
-      - name: Cache SHA image
-        uses: actions/cache/save@v4
-        with:
-          path: ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}_${{ github.sha }}.tar
-          key:  ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}_${{ github.sha }}
-
-      # Push developer's tag if exists and SHA tag always if pull-request and same repository OR push
+      # Push developer's and SHA tag image for internal PRs and pushes
       - name: Push developer's and SHA tag image
+        id: push
         if: >
           github.event_name == 'push' ||
           (github.event_name == 'pull_request' &&
@@ -104,3 +94,15 @@ jobs:
             docker push ${IMAGE,,}:$DEV_TAG
           fi
           docker push ${IMAGE,,}:${{ github.sha }}
+
+      # Save and cache only when push to GHCR did not succeed (fork PRs, unexpected failures)
+      - name: Save SHA image
+        if: steps.push.outcome != 'success'
+        run: docker save ${IMAGE,,}:${{ github.sha }} > ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}_${{ github.sha }}.tar
+
+      - name: Cache SHA image
+        if: steps.push.outcome != 'success'
+        uses: actions/cache/save@v4
+        with:
+          path: ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}_${{ github.sha }}.tar
+          key:  ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}_${{ github.sha }}


### PR DESCRIPTION
## Don't use actions cache if developer's image is present in GHCR

refactor (build): cache SHA image only when GHCR push did not succeed
- add `id: push` to the push step to expose its outcome to subsequent steps
- move Save/Cache steps after the push step instead of before
- gate Save and Cache on `steps.push.outcome != 'success'` to cover skipped, failed, and cancelled outcomes
- ensure the image exists in exactly one place: GHCR on successful push, cache otherwise

Task: [GG-162](https://tracker.yandex.ru/GG-162)