### PR TITLE
GG-180 Reduce default timeout for resgroup tests

### DIFF
--- a/.github/workflows/greengage-reusable-tests-resgroup.yml
+++ b/.github/workflows/greengage-reusable-tests-resgroup.yml
@@ -30,6 +30,7 @@ on:
 jobs:
   optimizer:
     runs-on: ubuntu-24.04
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
@@ -227,6 +228,7 @@ jobs:
           exit $EXIT_CODE
 
       - name: Run resgorup tests
+        timeout-minutes: 150
         run: |
           ${SSH_COMMAND} "cd /home/gpadmin \
                           && export \$(cat .env.tests | xargs) \


### PR DESCRIPTION
Reduce default timeout for resgroup tests

Currently, resgroup tests use the default timeout of 360 minutes. 
If the tests hang and reach this limit, the GitHub workflow hits its
maximum timeout and cancels all jobs immediately, preventing
logs from being collected (even with `always()` conditions).

This change sets the resgroup test timeout to 5 hours 30 minutes,
leaving an additional 30 minutes for log collection and uploading
results.