### PR TITLE
CI-5599: Detect '@skip' tag in Behave CI matrix generation

### DIFF
--- a/.github/actions/tests/regression/action.yml
+++ b/.github/actions/tests/regression/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: 'Greengage image for tests'
     required: true
   target_os:
-    description: 'Target OS for test (e.g., ubuntu, centos)'
+    description: 'Target OS (e.g., ubuntu)'
     required: true
   target_os_version:
     description: 'Target OS version (e.g., 22.04)'

--- a/.github/workflows/greengage-reusable-build.yml
+++ b/.github/workflows/greengage-reusable-build.yml
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
       target_os:
-        description: 'Target OS (e.g., ubuntu, centos, rockylinux)'
+        description: 'Target OS (e.g., ubuntu)'
         required: true
         type: string
       target_os_version:

--- a/.github/workflows/greengage-reusable-build.yml
+++ b/.github/workflows/greengage-reusable-build.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       target_os_version:
-        description: 'Target OS version (e.g., 22.04, 24.04)'
+        description: 'Target OS version (e.g., 24.04)'
         required: false
         type: string
         default: ''

--- a/.github/workflows/greengage-reusable-cleanup.yml
+++ b/.github/workflows/greengage-reusable-cleanup.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       target_os:
-        description: 'Target OS'
+        description: 'Target OS (e.g., ubuntu)'
         required: true
         type: string
       target_os_version:

--- a/.github/workflows/greengage-reusable-cleanup.yml
+++ b/.github/workflows/greengage-reusable-cleanup.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       target_os_version:
-        description: 'Target OS version (e.g., 22.04, 24.04)'
+        description: 'Target OS version (e.g., 24.04)'
         required: false
         type: string
         default: ''

--- a/.github/workflows/greengage-reusable-cleanup.yml
+++ b/.github/workflows/greengage-reusable-cleanup.yml
@@ -13,8 +13,9 @@ on:
         type: string
       target_os_version:
         description: 'Target OS version (e.g., 22.04, 24.04)'
-        required: true
+        required: false
         type: string
+        default: ''
     secrets:
       ghcr_token:
         description: 'GitHub token for GHCR access'

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       target_os:
-        description: 'Target OS'
+        description: 'Target OS (e.g., ubuntu)'
         required: true
         type: string
       target_os_version:

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       target_os_version:
-        description: 'Target OS version (e.g., 22.04, 24.04)'
+        description: 'Target OS version (e.g., 24.04)'
         required: false
         type: string
         default: ''

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -15,6 +15,7 @@ on:
         description: 'Target OS version (e.g., 22.04, 24.04)'
         required: false
         type: string
+        default: ''
       rebuild_builder:
         description: 'Rebuild builder image required'
         required: false

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -14,7 +14,7 @@ on:
         required: true
         type: string
       target_os:
-        description: 'Target OS for build (e.g., ubuntu)'
+        description: 'Target OS (e.g., ubuntu)'
         required: true
         type: string
       target_os_version:

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -35,7 +35,6 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       run_matrix: ${{ steps.set-matrix.outputs.run_matrix }}
-      skip_matrix: ${{ steps.set-matrix.outputs.skip_matrix }}
     steps:
       - name: Checkout Greengage repo
         uses: actions/checkout@v4
@@ -63,7 +62,12 @@ jobs:
           done | jq -s -c '.')
 
           echo "run_matrix=$run_array" >> $GITHUB_OUTPUT
-          echo "skip_matrix=$skip_array" >> $GITHUB_OUTPUT
+
+          echo "## Behave Test Matrix" >> $GITHUB_STEP_SUMMARY
+          echo "### ✅ Will run" >> $GITHUB_STEP_SUMMARY
+          echo "$run_array" | jq -r '.[]' | while read -r f; do echo "- $f"; done >> $GITHUB_STEP_SUMMARY
+          echo "### ⏭️ Skipped (@skip tag detected)" >> $GITHUB_STEP_SUMMARY
+          echo "$skip_array" | jq -r '.[]' | while read -r f; do echo "- $f"; done >> $GITHUB_STEP_SUMMARY
 
   behave:
     needs: generate-matrix
@@ -155,20 +159,8 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore  # Ignore if no artifacts are found
 
-  behave-skipped:
-    needs: generate-matrix
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        feature: ${{ fromJson(needs.generate-matrix.outputs.skip_matrix) }}
-    steps:
-      - name: Feature ${{ matrix.feature }} is skipped via @skip tag
-        run: echo "skipped"
-        if: false
-
   collect-results:
-    needs: [behave, behave-skipped]
+    needs: behave
     if: always()
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -19,6 +19,7 @@ on:
         type: string
       target_os_version:
         description: 'Target OS version (e.g., 22.04, 24.04)'
+        required: false
         type: string
       python3:
         description: 'Python3 build argument (ignored)'

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -60,7 +60,7 @@ jobs:
   behave:
     needs: generate-matrix
     runs-on: ubuntu-24.04
-    if: ${{ !matrix.feature.skip }}
+    if: matrix.feature.skip == false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -34,7 +34,8 @@ jobs:
   generate-matrix:
     runs-on: ubuntu-24.04
     outputs:
-      feature_matrix: ${{ steps.set-matrix.outputs.feature_matrix }}
+      run_matrix: ${{ steps.set-matrix.outputs.run_matrix }}
+      skip_matrix: ${{ steps.set-matrix.outputs.skip_matrix }}
     steps:
       - name: Checkout Greengage repo
         uses: actions/checkout@v4
@@ -48,23 +49,29 @@ jobs:
         run: |
           behave_tests_dir="gpMgmt/test/behave/mgmt_utils"
           features=$(ls $behave_tests_dir -1 | grep feature | sed 's/\.feature$//')
-          feature_array=$(echo "$features" | while IFS= read -r f; do
-            if grep -qE '^@.*\bskip\b' "$behave_tests_dir/$f.feature" 2>/dev/null; then
-              echo "{\"name\":\"$f\",\"skip\":true}"
-            else
-              echo "{\"name\":\"$f\",\"skip\":false}"
+
+          run_array=$(echo "$features" | while IFS= read -r f; do
+            if ! grep -qE '^@.*\bskip\b' "$behave_tests_dir/$f.feature" 2>/dev/null; then
+              echo "\"$f\""
             fi
           done | jq -s -c '.')
-          echo "feature_matrix=$feature_array" >> $GITHUB_OUTPUT
+
+          skip_array=$(echo "$features" | while IFS= read -r f; do
+            if grep -qE '^@.*\bskip\b' "$behave_tests_dir/$f.feature" 2>/dev/null; then
+              echo "\"$f\""
+            fi
+          done | jq -s -c '.')
+
+          echo "run_matrix=$run_array" >> $GITHUB_OUTPUT
+          echo "skip_matrix=$skip_array" >> $GITHUB_OUTPUT
 
   behave:
     needs: generate-matrix
     runs-on: ubuntu-24.04
-    if: matrix.feature.skip == false
     strategy:
       fail-fast: false
       matrix:
-        feature: ${{ fromJson(needs.generate-matrix.outputs.feature_matrix) }}
+        feature: ${{ fromJson(needs.generate-matrix.outputs.run_matrix) }}
     permissions:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
@@ -90,8 +97,8 @@ jobs:
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1
 
-      - name: Fetch SQL dump for ${{ matrix.feature.name }}
-        if: matrix.feature.name == 'gpexpand'
+      - name: Fetch SQL dump for ${{ matrix.feature }}
+        if: matrix.feature == 'gpexpand'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -119,26 +126,26 @@ jobs:
             exit 1
           fi
 
-      - name: Run Behave feature ${{ matrix.feature.name }}
+      - name: Run Behave feature ${{ matrix.feature }}
         # continue-on-error: true
         env:
           IMAGE: ghcr.io/${{ github.repository }}/ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}:${{ github.sha }}
         run: |
           export IMAGE=${IMAGE,,}
-          bash ci/scripts/run_behave_tests.bash ${{ matrix.feature.name }}
+          bash ci/scripts/run_behave_tests.bash ${{ matrix.feature }}
 
-      - name: Collect logs ${{ matrix.feature.name }}
+      - name: Collect logs ${{ matrix.feature }}
         if: always()
         uses: greengagedb/greengage-ci/.github/actions/collect-logs@v26
         with:
-          log_path_prefix: "behave_${{ matrix.feature.name }}"
+          log_path_prefix: "behave_${{ matrix.feature }}"
 
       # Upload feature artifacts
-      - name: Upload ${{ matrix.feature.name }} artifacts
+      - name: Upload ${{ matrix.feature }} artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.job }}_${{ matrix.feature.name }}_ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}_results
+          name: ${{ github.job }}_${{ matrix.feature }}_ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}_results
           path: |
             allure-results
             logs_cdw
@@ -148,8 +155,20 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore  # Ignore if no artifacts are found
 
+  behave-skipped:
+    needs: generate-matrix
+    runs-on: ubuntu-24.04
+    if: false
+    strategy:
+      fail-fast: false
+      matrix:
+        feature: ${{ fromJson(needs.generate-matrix.outputs.skip_matrix) }}
+    steps:
+      - name: Feature ${{ matrix.feature }} is skipped via @skip tag
+        run: echo "skipped"
+
   collect-results:
-    needs: behave
+    needs: [behave, behave-skipped]
     if: always()
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -21,6 +21,7 @@ on:
         description: 'Target OS version (e.g., 22.04, 24.04)'
         required: false
         type: string
+        default: ''
       python3:
         description: 'Python3 build argument (ignored)'
         required: false

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -64,10 +64,10 @@ jobs:
           echo "run_matrix=$run_array" >> $GITHUB_OUTPUT
 
           echo "## Behave Test Matrix" >> $GITHUB_STEP_SUMMARY
-          echo "### ✅ Will run" >> $GITHUB_STEP_SUMMARY
-          echo "$run_array" | jq -r '.[]' | while read -r f; do echo "- $f"; done >> $GITHUB_STEP_SUMMARY
           echo "### ⏭️ Skipped (@skip tag detected)" >> $GITHUB_STEP_SUMMARY
           echo "$skip_array" | jq -r '.[]' | while read -r f; do echo "- $f"; done >> $GITHUB_STEP_SUMMARY
+          echo "### ✅ Will run" >> $GITHUB_STEP_SUMMARY
+          echo "$run_array" | jq -r '.[]' | while read -r f; do echo "- $f"; done >> $GITHUB_STEP_SUMMARY
 
   behave:
     needs: generate-matrix

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -48,12 +48,19 @@ jobs:
         run: |
           behave_tests_dir="gpMgmt/test/behave/mgmt_utils"
           features=$(ls $behave_tests_dir -1 | grep feature | sed 's/\.feature$//')
-          feature_array=$(echo "$features" | jq -R -s -c 'split("\n") | map(select(. != ""))')
+          feature_array=$(echo "$features" | while IFS= read -r f; do
+            if grep -qE '^@.*\bskip\b' "$behave_tests_dir/$f.feature" 2>/dev/null; then
+              echo "{\"name\":\"$f\",\"skip\":true}"
+            else
+              echo "{\"name\":\"$f\",\"skip\":false}"
+            fi
+          done | jq -s -c '.')
           echo "feature_matrix=$feature_array" >> $GITHUB_OUTPUT
 
   behave:
     needs: generate-matrix
     runs-on: ubuntu-24.04
+    if: ${{ !matrix.feature.skip }}
     strategy:
       fail-fast: false
       matrix:
@@ -83,8 +90,9 @@ jobs:
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1
 
-      - name: Fetch SQL dump for ${{ matrix.feature }}
-        if: matrix.feature == 'gpexpand'
+      - name: Fetch SQL dump for ${{ matrix.feature.name }}
+        if: matrix.feature.name == 'gpexpand'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -111,26 +119,26 @@ jobs:
             exit 1
           fi
 
-      - name: Run Behave feature ${{ matrix.feature }}
+      - name: Run Behave feature ${{ matrix.feature.name }}
         # continue-on-error: true
         env:
           IMAGE: ghcr.io/${{ github.repository }}/ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}:${{ github.sha }}
         run: |
           export IMAGE=${IMAGE,,}
-          bash ci/scripts/run_behave_tests.bash ${{ matrix.feature }}
+          bash ci/scripts/run_behave_tests.bash ${{ matrix.feature.name }}
 
-      - name: Collect logs ${{ matrix.feature }}
+      - name: Collect logs ${{ matrix.feature.name }}
         if: always()
         uses: greengagedb/greengage-ci/.github/actions/collect-logs@v26
         with:
-          log_path_prefix: "behave_${{ matrix.feature }}"
+          log_path_prefix: "behave_${{ matrix.feature.name }}"
 
       # Upload feature artifacts
-      - name: Upload ${{ matrix.feature }} artifacts
+      - name: Upload ${{ matrix.feature.name }} artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.job }}_${{ matrix.feature }}_ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}_results
+          name: ${{ github.job }}_${{ matrix.feature.name }}_ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}_results
           path: |
             allure-results
             logs_cdw

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -18,7 +18,7 @@ on:
         required: true
         type: string
       target_os_version:
-        description: 'Target OS version (e.g., 22.04, 24.04)'
+        description: 'Target OS version (e.g., 24.04)'
         required: false
         type: string
         default: ''

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -48,7 +48,7 @@ jobs:
         id: set-matrix
         run: |
           behave_tests_dir="gpMgmt/test/behave/mgmt_utils"
-          features=$(ls $behave_tests_dir -1 | grep feature | sed 's/\.feature$//')
+          features=$(for f in "$behave_tests_dir"/*.feature; do basename "$f" .feature; done)
 
           run_array=$(echo "$features" | while IFS= read -r f; do
             if ! grep -qE '^@.*\bskip\b' "$behave_tests_dir/$f.feature" 2>/dev/null; then

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -158,7 +158,6 @@ jobs:
   behave-skipped:
     needs: generate-matrix
     runs-on: ubuntu-24.04
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -166,6 +165,7 @@ jobs:
     steps:
       - name: Feature ${{ matrix.feature }} is skipped via @skip tag
         run: echo "skipped"
+        if: false
 
   collect-results:
     needs: [behave, behave-skipped]

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -194,6 +194,7 @@ jobs:
       # Generate Allure report
       - name: Generate Allure report
         run: |
+          set -e
           cd artifacts
           [ -d allure-results ] && allure generate allure-results -o allure-report --clean || echo "No allure-results to generate report"
 

--- a/.github/workflows/greengage-reusable-tests-jit.yml
+++ b/.github/workflows/greengage-reusable-tests-jit.yml
@@ -14,7 +14,7 @@ on:
         required: true
         type: string
       target_os:
-        description: 'Target OS for build (e.g., ubuntu)'
+        description: 'Target OS (e.g., ubuntu)'
         type: string
       target_os_version:
         description: 'Target OS version (e.g., 24.04)'

--- a/.github/workflows/greengage-reusable-tests-jit.yml
+++ b/.github/workflows/greengage-reusable-tests-jit.yml
@@ -17,7 +17,7 @@ on:
         description: 'Target OS for build (e.g., ubuntu)'
         type: string
       target_os_version:
-        description: 'Target OS version (e.g., 22.04, 24.04)'
+        description: 'Target OS version (e.g., 24.04)'
         required: false
         type: string
         default: ''

--- a/.github/workflows/greengage-reusable-tests-orca.yml
+++ b/.github/workflows/greengage-reusable-tests-orca.yml
@@ -21,6 +21,7 @@ on:
         description: 'Target OS version (e.g., 22.04, 24.04)'
         required: false
         type: string
+        default: ''
       python3:
         description: 'Python3 build argument (ignored)'
         required: false

--- a/.github/workflows/greengage-reusable-tests-orca.yml
+++ b/.github/workflows/greengage-reusable-tests-orca.yml
@@ -18,7 +18,7 @@ on:
         required: true
         type: string
       target_os_version:
-        description: 'Target OS version (e.g., 22.04, 24.04)'
+        description: 'Target OS version (e.g., 24.04)'
         required: false
         type: string
         default: ''

--- a/.github/workflows/greengage-reusable-tests-orca.yml
+++ b/.github/workflows/greengage-reusable-tests-orca.yml
@@ -14,7 +14,7 @@ on:
         required: true
         type: string
       target_os:
-        description: 'Target OS for build (e.g., ubuntu, centos, rockylinux)'
+        description: 'Target OS (e.g., ubuntu)'
         required: true
         type: string
       target_os_version:

--- a/.github/workflows/greengage-reusable-tests-regression.yml
+++ b/.github/workflows/greengage-reusable-tests-regression.yml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
       target_os:
-        description: 'Target OS for build (e.g., ubuntu)'
+        description: 'Target OS (e.g., ubuntu)'
         required: true
         type: string
       target_os_version:

--- a/.github/workflows/greengage-reusable-tests-regression.yml
+++ b/.github/workflows/greengage-reusable-tests-regression.yml
@@ -19,7 +19,7 @@ on:
         required: true
         type: string
       target_os_version:
-        description: 'Target OS version (e.g., 22.04, 24.04)'
+        description: 'Target OS version (e.g., 24.04)'
         required: false
         type: string
         default: ''

--- a/.github/workflows/greengage-reusable-tests-resgroup.yml
+++ b/.github/workflows/greengage-reusable-tests-resgroup.yml
@@ -17,6 +17,7 @@ on:
         description: 'Target OS version (e.g., 22.04, 24.04)'
         required: false
         type: string
+        default: ''
       python3:
         description: 'Python3 build argument (ignored)'
         required: false

--- a/.github/workflows/greengage-reusable-tests-resgroup.yml
+++ b/.github/workflows/greengage-reusable-tests-resgroup.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       target_os:
-        description: 'Target OS for build (e.g., ubuntu, centos, rockylinux)'
+        description: 'Target OS (e.g., ubuntu)'
         required: true
         type: string
       target_os_version:

--- a/.github/workflows/greengage-reusable-tests-resgroup.yml
+++ b/.github/workflows/greengage-reusable-tests-resgroup.yml
@@ -14,7 +14,7 @@ on:
         required: true
         type: string
       target_os_version:
-        description: 'Target OS version (e.g., 22.04, 24.04)'
+        description: 'Target OS version (e.g., 24.04)'
         required: false
         type: string
         default: ''

--- a/.github/workflows/greengage-reusable-upload.yml
+++ b/.github/workflows/greengage-reusable-upload.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       target_os_version:
-        description: 'Target OS version (e.g., 22.04, 24.04)'
+        description: 'Target OS version (e.g., 24.04)'
         required: false
         type: string
         default: ''

--- a/.github/workflows/greengage-reusable-upload.yml
+++ b/.github/workflows/greengage-reusable-upload.yml
@@ -16,6 +16,7 @@ on:
         description: 'Target OS version (e.g., 22.04, 24.04)'
         required: false
         type: string
+        default: ''
       python3:
         description: 'Python3 build argument'
         required: false

--- a/.github/workflows/greengage-reusable-upload.yml
+++ b/.github/workflows/greengage-reusable-upload.yml
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
       target_os:
-        description: 'Target OS'
+        description: 'Target OS (e.g., ubuntu)'
         required: true
         type: string
       target_os_version:

--- a/README/REUSABLE-BUILD.md
+++ b/README/REUSABLE-BUILD.md
@@ -24,7 +24,7 @@ To integrate this workflow into your pipeline:
 |---------------------|---------------------------------------------------|----------|---------|---------|
 | `version`           | Greengage version (e.g., `6` or `7`)              | Yes      | String  | -       |
 | `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
-| `target_os_version` | Target OS version (e.g., `22.04`, `24.04`)        | No       | String  | `''`    |
+| `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
 | `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
 
 ### Secrets

--- a/README/REUSABLE-CLEANUP.md
+++ b/README/REUSABLE-CLEANUP.md
@@ -20,11 +20,11 @@ To integrate this workflow into your pipeline:
 
 ### Inputs
 
-Name                | Description                                | Required | Type   | Default
-------------------- | ------------------------------------------ | -------- | ------ | -------
-`version`           | Greengage version (e.g., `6` or `7`)       | Yes      | String | -
-`target_os`         | Target operating system (e.g., `ubuntu`)   | Yes      | String | -
-`target_os_version` | Target OS version (e.g., `22.04`, `24.04`) | Yes      | String | -
+Name                | Description                              | Required | Type   | Default
+------------------- | -----------------------------------------| -------- | ------ | -------
+`version`           | Greengage version (e.g., `6` or `7`)     | Yes      | String | -
+`target_os`         | Target operating system (e.g., `ubuntu`) | Yes      | String | -
+`target_os_version` | Target OS version (e.g., ``, `24.04`)    | Yes      | String | -
 
 ### Secrets
 
@@ -51,7 +51,6 @@ Name         | Description                  | Required
       with:
         version: 7
         target_os: ubuntu
-        target_os_version: '22.04'
       secrets:
         ghcr_token: ${{ secrets.GITHUB_TOKEN }}
   ```
@@ -66,7 +65,6 @@ Name         | Description                  | Required
         matrix:
           include:
             - target_os: ubuntu
-              target_os_version: '22.04'
             - target_os: ubuntu
               target_os_version: '24.04'
       permissions:

--- a/README/REUSABLE-CLEANUP.md
+++ b/README/REUSABLE-CLEANUP.md
@@ -20,17 +20,17 @@ To integrate this workflow into your pipeline:
 
 ### Inputs
 
-Name                | Description                              | Required | Type   | Default
-------------------- | -----------------------------------------| -------- | ------ | -------
-`version`           | Greengage version (e.g., `6` or `7`)     | Yes      | String | -
-`target_os`         | Target operating system (e.g., `ubuntu`) | Yes      | String | -
-`target_os_version` | Target OS version (e.g., ``, `24.04`)    | Yes      | String | -
+| Name                | Description                                       | Required | Type    | Default |
+|---------------------|---------------------------------------------------|----------|---------|---------|
+| `version`           | Greengage version (e.g., `6` or `7`)              | Yes      | String  | -       |
+| `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
+| `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
 
 ### Secrets
 
-Name         | Description                  | Required
------------- | ---------------------------- | --------
-`ghcr_token` | GitHub token for GHCR access | Yes
+|Name         | Description                  | Required|
+|------------ | ---------------------------- | --------|
+|`ghcr_token` | GitHub token for GHCR access | Yes     |
 
 ### Requirements
 

--- a/README/REUSABLE-PACKAGE.md
+++ b/README/REUSABLE-PACKAGE.md
@@ -74,7 +74,7 @@ Name                | Description                                          | Req
 ------------------- | ---------------------------------------------------- | -------- | ------- | -------
 `version`           | Version derived from tag (e.g., `6` or `7`)          | Yes      | String  | -
 `target_os`         | Target operating system (e.g., `ubuntu`)             | Yes      | String  | -
-`target_os_version` | Target OS version (e.g., ``, `24.04`)                | Yes      | String  | -
+`target_os_version` | Target OS version (e.g., ``, `24.04`)                | No      | String  | -
 `rebuild_builder`   | Rebuild builder image even if it exists              | No       | Boolean | `false`
 `test_lima`         | Lima template (e.g., `ubuntu-22.04`) for deploy test | No       | String  | `''`
 `test_docker`       | Docker image (e.g., `ubuntu:22.04`) for deploy test  | No       | String  | `''`

--- a/README/REUSABLE-PACKAGE.md
+++ b/README/REUSABLE-PACKAGE.md
@@ -20,45 +20,45 @@ The workflow processes the source code to build and test Debian packages. Below 
 
 1. **Build Debian Packages** (`build-deb`):
 
-  - Checks out the repository with submodules and full history.
-  - Logs into the GitHub Container Registry (GHCR) using the provided token.
-  - Builds or pulls a builder Docker image (`ghcr.io/<repo>/ggdb<version>_<target_os><target_os_version>:builder`) based on the `rebuild_builder` input:
+   - Checks out the repository with submodules and full history.
+   - Logs into the GitHub Container Registry (GHCR) using the provided token.
+   - Builds or pulls a builder Docker image (`ghcr.io/<repo>/ggdb<version>_<target_os><target_os_version>:builder`) based on the `rebuild_builder` input:
 
-    - If `rebuild_builder` is `true` or the builder image does not exist, builds and pushes the image using `Dockerfile.ubuntu.builder`.
-    - Otherwise, pulls the existing builder image.
+     - If `rebuild_builder` is `true` or the builder image does not exist, builds and pushes the image using `Dockerfile.ubuntu.builder`.
+     - Otherwise, pulls the existing builder image.
 
-  - Runs the builder image to compile Debian packages using `make -C gpdb_src/gpAux pkg-deb` with parallel compilation based on available CPU cores.
+   - Runs the builder image to compile Debian packages using `make -C gpdb_src/gpAux pkg-deb` with parallel compilation based on available CPU cores.
 
-  - Determines changelog options based on the event:
+   - Determines changelog options based on the event:
 
-    - For tagged push events (`refs/tags/*`), uses default changelog options.
-    - For branch pushes, includes all commits since the last tag (`last-tag all-commits`).
+     - For tagged push events (`refs/tags/*`), uses default changelog options.
+     - For branch pushes, includes all commits since the last tag (`last-tag all-commits`).
 
-  - Uploads generated artifacts (`.deb`, `.ddeb`, `.build`, `.buildinfo`, `.changes`) as `deb-packages`.
+   - Uploads generated artifacts (`.deb`, `.ddeb`, `.build`, `.buildinfo`, `.changes`) as `deb-packages`.
 
 2. **Test Installation in Lima** (`test-lima`, if `test_lima` is provided):
 
-  - Sets up Lima and caches its configuration.
-  - Downloads the `deb-packages` artifact.
-  - Starts a Lima VM with the specified template (e.g., `ubuntu-22.04`), configured with 4 CPUs, 8GB memory, and a 9p filesystem mount.
-  - Copies the Debian packages to the VM and installs them using `apt-get install` or `dpkg -i` with `apt-get install -f` for dependency resolution.
-  - Uploads installation logs as `install-logs`.
-  - Cleans up the Lima VM on completion or failure.
+   - Sets up Lima and caches its configuration.
+   - Downloads the `deb-packages` artifact.
+   - Starts a Lima VM with the specified template (e.g., `ubuntu-22.04`), configured with 4 CPUs, 8GB memory, and a 9p filesystem mount.
+   - Copies the Debian packages to the VM and installs them using `apt-get install` or `dpkg -i` with `apt-get install -f` for dependency resolution.
+   - Uploads installation logs as `install-logs`.
+   - Cleans up the Lima VM on completion or failure.
 
 3. **Test Installation in Docker** (`test-docker`, if `test_docker` is provided):
 
-  - Downloads the `deb-packages` artifact.
-  - Runs a Docker container with the specified image (e.g., `ubuntu:<target_os_version>`).
-  - Installs the Debian packages using `apt-get install` or `dpkg -i` with `apt-get install -f` for dependency resolution.
-  - Uploads installation logs as `install-logs-docker`.
+   - Downloads the `deb-packages` artifact.
+   - Runs a Docker container with the specified image (e.g., `ubuntu:<target_os_version>`).
+   - Installs the Debian packages using `apt-get install` or `dpkg -i` with `apt-get install -f` for dependency resolution.
+   - Uploads installation logs as `install-logs-docker`.
 
 4. **Failure Conditions**:
 
-  - If the builder image build or pull fails, the `build-deb` job exits with an error.
-  - If `target_os` is not `ubuntu`, the `build-deb` job is skipped.
-  - If the Debian package build fails (e.g., due to missing dependencies or compilation errors), the `build-deb` job exits with an error.
-  - If installation in Lima or Docker fails, the respective test job exits with an error, but subsequent jobs are not blocked.
-  - If `ghcr_token` is invalid or lacks permissions, GHCR login fails, causing the workflow to exit.
+   - If the builder image build or pull fails, the `build-deb` job exits with an error.
+   - If `target_os` is not `ubuntu`, the `build-deb` job is skipped.
+   - If the Debian package build fails (e.g., due to missing dependencies or compilation errors), the `build-deb` job exits with an error.
+   - If installation in Lima or Docker fails, the respective test job exits with an error, but subsequent jobs are not blocked.
+   - If `ghcr_token` is invalid or lacks permissions, GHCR login fails, causing the workflow to exit.
 
 ## Usage
 
@@ -70,20 +70,20 @@ To integrate this workflow into your pipeline:
 
 ### Inputs
 
-Name                | Description                                          | Required | Type    | Default
-------------------- | ---------------------------------------------------- | -------- | ------- | -------
-`version`           | Version derived from tag (e.g., `6` or `7`)          | Yes      | String  | -
-`target_os`         | Target operating system (e.g., `ubuntu`)             | Yes      | String  | -
-`target_os_version` | Target OS version (e.g., ``, `24.04`)                | No      | String  | -
-`rebuild_builder`   | Rebuild builder image even if it exists              | No       | Boolean | `false`
-`test_lima`         | Lima template (e.g., `ubuntu-22.04`) for deploy test | No       | String  | `''`
-`test_docker`       | Docker image (e.g., `ubuntu:22.04`) for deploy test  | No       | String  | `''`
+| Name                | Description                                          | Required | Type    | Default |
+|---------------------|------------------------------------------------------|----------|---------|---------|
+| `version`           | Greengage version (e.g., `6` or `7`)                 | Yes      | String  | -       |
+| `target_os`         | Target operating system (e.g., `ubuntu`)             | Yes      | String  | -       |
+| `target_os_version` | Target OS version (e.g., ``, `24.04`)                | No       | String  | `''`    |
+| `rebuild_builder`   | Rebuild builder image even if it exists              | No       | Boolean | `false` |
+| `test_lima`         | Lima template (e.g., `ubuntu-22.04`) for deploy test | No       | String  | `''`    |
+| `test_docker`       | Docker image (e.g., `ubuntu:22.04`) for deploy test  | No       | String  | `''`    |
 
 ### Secrets
 
-Name         | Description                  | Required
------------- | ---------------------------- | --------
-`ghcr_token` | GitHub token for GHCR access | Yes
+|Name         | Description                  | Required|
+|------------ | ---------------------------- | --------|
+|`ghcr_token` | GitHub token for GHCR access | Yes     |
 
 ### Requirements
 

--- a/README/REUSABLE-PACKAGE.md
+++ b/README/REUSABLE-PACKAGE.md
@@ -74,7 +74,7 @@ Name                | Description                                          | Req
 ------------------- | ---------------------------------------------------- | -------- | ------- | -------
 `version`           | Version derived from tag (e.g., `6` or `7`)          | Yes      | String  | -
 `target_os`         | Target operating system (e.g., `ubuntu`)             | Yes      | String  | -
-`target_os_version` | Target OS version (e.g., `22.04`, `24.04`)           | Yes      | String  | -
+`target_os_version` | Target OS version (e.g., ``, `24.04`)                | Yes      | String  | -
 `rebuild_builder`   | Rebuild builder image even if it exists              | No       | Boolean | `false`
 `test_lima`         | Lima template (e.g., `ubuntu-22.04`) for deploy test | No       | String  | `''`
 `test_docker`       | Docker image (e.g., `ubuntu:22.04`) for deploy test  | No       | String  | `''`
@@ -107,7 +107,6 @@ Name         | Description                  | Required
       with:
         version: 6
         target_os: ubuntu
-        target_os_version: '22.04'
         rebuild_builder: false
         test_lima: ubuntu-22.04
         test_docker: ubuntu:22.04
@@ -125,7 +124,6 @@ Name         | Description                  | Required
         matrix:
           include:
             - target_os: ubuntu
-              target_os_version: '22.04'
             - target_os: ubuntu
               target_os_version: '24.04'
       permissions:

--- a/README/REUSABLE-TESTS-BEHAVE.md
+++ b/README/REUSABLE-TESTS-BEHAVE.md
@@ -10,9 +10,9 @@ This workflow runs Behave test suites for the Greengage project in a containeriz
 
 The workflow executes Behave tests using a Docker image built for the given Greengage version and target operating system. Test features are dynamically discovered from the `gpMgmt/test/behave/mgmt_utils` directory — each `.feature` file found is executed as a separate job in a matrix strategy.
 
-> **Note**: Test filtering is handled via `@skip` tags within individual test files. The workflow itself does not apply any filters or exclusions to the discovered features.
+> **Note**: Features tagged with `@skip` on the `Feature:` line are detected during matrix generation and their corresponding jobs are skipped at the CI level. Skipped jobs appear as grey (skipped) in the GitHub Actions UI, making it immediately visible which tests are disabled.
 
-For the `gpexpand` feature, the workflow automatically fetches a SQL dump artifact from a previous "Greengage SQL Dump" workflow run before executing tests.
+For the `gpexpand` feature, the workflow attempts to fetch a SQL dump artifact from a previous "Greengage SQL Dump" workflow run before executing tests. If the artifact is unavailable, the download step is allowed to fail — the failure will surface in the `gpexpand` test run itself.
 
 The workflow generates test artifacts (e.g., Allure reports, logs) and uploads them to GitHub Actions artifacts, with a final aggregated Allure report generated in the `collect-results` job.
 
@@ -59,7 +59,7 @@ Name         | Description                  | Required
 - **Docker Image**: Ensure a Docker image exists in GHCR matching the format `ghcr.io/<repo>/ggdb<version>_<target_os><target_os_version>:<full-sha>`.
 - **Repository Access**: The workflow checks out the repository specified in `github.repository`.
 - **Artifacts**: The workflow uploads artifacts (e.g., `allure-results`, `logs`, `logs_cdw`, `logs_sdw1`) and a final aggregated Allure report.
-- **SQL Dump**: For the `gpexpand` feature, a SQL dump artifact must be available from a previous "Greengage SQL Dump" workflow run.
+- **SQL Dump**: For the `gpexpand` feature, a SQL dump artifact from a previous "Greengage SQL Dump" workflow run is expected. If unavailable, the test run itself will fail.
 
 ## Examples
 
@@ -112,8 +112,8 @@ Name         | Description                  | Required
 
 - The Docker image is expected to be tagged with the full commit SHA (e.g., `ghcr.io/<owner>/<repo>/ggdb6_ubuntu:<full-sha>`).
 - Test features are dynamically discovered from `gpMgmt/test/behave/mgmt_utils` — each `.feature` file is executed as a separate matrix job.
-- Test filtering is handled via `@skip` tags within individual test files, not by the workflow.
-- For the `gpexpand` feature, ensure a SQL dump artifact is available from a previous "Greengage SQL Dump" workflow run.
+- Features tagged with `@skip` on the `Feature:` line are detected during matrix generation and skipped at the CI level — their jobs appear as grey (skipped) in the GitHub Actions UI rather than green, providing accurate test observability.
+- For the `gpexpand` feature, the SQL dump download is allowed to fail without breaking the workflow — a missing dump will cause the `gpexpand` test job itself to fail.
 - Artifacts are uploaded with names like `behave_<feature>_ggdb<version>_<target_os><target_os_version>_results`, and a final aggregated report is named `behave_all_ggdb<version>_<target_os><target_os_version>`.
 - Ensure the Behave test environment is configured correctly in the repository (e.g., `ci/docker-compose.yaml`, `ci/.env`).
 

--- a/README/REUSABLE-TESTS-BEHAVE.md
+++ b/README/REUSABLE-TESTS-BEHAVE.md
@@ -76,7 +76,6 @@ Name         | Description                  | Required
       with:
         version: 7
         target_os: ubuntu
-        target_os_version: '22.04'
         python3: ''
       secrets:
         ghcr_token: ${{ secrets.GITHUB_TOKEN }}
@@ -92,7 +91,6 @@ Name         | Description                  | Required
         matrix:
           include:
             - target_os: ubuntu
-              target_os_version: '22.04'
             - target_os: ubuntu
               target_os_version: '24.04'
       permissions:

--- a/README/REUSABLE-TESTS-BEHAVE.md
+++ b/README/REUSABLE-TESTS-BEHAVE.md
@@ -38,19 +38,19 @@ To integrate this workflow into your pipeline:
 
 ### Inputs
 
-Name                | Description                                                      | Required | Type   | Default
-------------------- | ---------------------------------------------------------------- | -------- | ------ | -------
-`version`           | Greengage version (e.g., `6` or `7`)                             | Yes      | String | -
-`target_os`         | Target operating system (e.g., `ubuntu`, `centos`, `rockylinux`) | Yes      | String | -
-`target_os_version` | Target OS version (e.g., `20.04`, `22.04`, `7`, `8`)             | Yes      | String | -
-`python3`           | Python3 build argument (ignored)                                 | No       | String | `''`
-`ref`               | Branch or tag to checkout (e.g., `main`, `7.x`)                  | No       | String | `''`
+| Name                | Description                                       | Required | Type    | Default |
+|---------------------|---------------------------------------------------|----------|---------|---------|
+| `version`           | Greengage version (e.g., `6` or `7`)              | Yes      | String  | -       |
+| `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
+| `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
+| `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
+| `python3`           | Python3 build argument (ignored)                  | No       | String  | `''`    |
 
 ### Secrets
 
-Name         | Description                  | Required
------------- | ---------------------------- | --------
-`ghcr_token` | GitHub token for GHCR access | Yes
+|Name         | Description                  | Required|
+|------------ | ---------------------------- | --------|
+|`ghcr_token` | GitHub token for GHCR access | Yes     |
 
 ## Requirements
 

--- a/README/REUSABLE-TESTS-BEHAVE.md
+++ b/README/REUSABLE-TESTS-BEHAVE.md
@@ -10,7 +10,7 @@ This workflow runs Behave test suites for the Greengage project in a containeriz
 
 The workflow executes Behave tests using a Docker image built for the given Greengage version and target operating system. Test features are dynamically discovered from the `gpMgmt/test/behave/mgmt_utils` directory — each `.feature` file found is executed as a separate job in a matrix strategy.
 
-> **Note**: Features tagged with `@skip` on the `Feature:` line are detected during matrix generation and their corresponding jobs are skipped at the CI level. Skipped jobs appear as grey (skipped) in the GitHub Actions UI, making it immediately visible which tests are disabled.
+> **Note**: Features tagged with `@skip` on the `Feature:` line are detected during matrix generation and excluded from the run matrix. Skipped features are listed in the Job Summary of the `generate-matrix` step, making it immediately visible which tests are disabled.
 
 For the `gpexpand` feature, the workflow attempts to fetch a SQL dump artifact from a previous "Greengage SQL Dump" workflow run before executing tests. If the artifact is unavailable, the download step is allowed to fail — the failure will surface in the `gpexpand` test run itself.
 
@@ -110,7 +110,7 @@ Name         | Description                  | Required
 
 - The Docker image is expected to be tagged with the full commit SHA (e.g., `ghcr.io/<owner>/<repo>/ggdb6_ubuntu:<full-sha>`).
 - Test features are dynamically discovered from `gpMgmt/test/behave/mgmt_utils` — each `.feature` file is executed as a separate matrix job.
-- Features tagged with `@skip` on the `Feature:` line are detected during matrix generation and skipped at the CI level — their jobs appear as grey (skipped) in the GitHub Actions UI rather than green, providing accurate test observability.
+- Features tagged with `@skip` on the `Feature:` line are detected during matrix generation and excluded from the run matrix — skipped features are listed in the Job Summary of the `generate-matrix` step, providing accurate test observability.
 - For the `gpexpand` feature, the SQL dump download is allowed to fail without breaking the workflow — a missing dump will cause the `gpexpand` test job itself to fail.
 - Artifacts are uploaded with names like `behave_<feature>_ggdb<version>_<target_os><target_os_version>_results`, and a final aggregated report is named `behave_all_ggdb<version>_<target_os><target_os_version>`.
 - Ensure the Behave test environment is configured correctly in the repository (e.g., `ci/docker-compose.yaml`, `ci/.env`).

--- a/README/REUSABLE-TESTS-ORCA.md
+++ b/README/REUSABLE-TESTS-ORCA.md
@@ -29,7 +29,7 @@ Name                | Description                                     | Required
 ------------------- | ----------------------------------------------- | -------- | ------ | -------
 `version`           | Greengage version (e.g., `6` or `7`)            | Yes      | String | -
 `target_os`         | Target operating system (e.g., `ubuntu`)        | Yes      | String | -
-`target_os_version` | Target OS version (e.g., `22.04`, `24.04`)      | Yes      | String | -
+`target_os_version` | Target OS version (e.g., ``, `24.04`)           | Yes      | String | -
 `python3`           | Python3 build argument (ignored)                | No       | String | `''`
 `ref`               | Branch or tag to checkout (e.g., `main`, `7.x`) | No       | String | `''`
 
@@ -62,7 +62,6 @@ Name         | Description                  | Required
       with:
         version: 7
         target_os: ubuntu
-        target_os_version: '22.04'
         python3: ''
       secrets:
         ghcr_token: ${{ secrets.GITHUB_TOKEN }}
@@ -78,7 +77,6 @@ Name         | Description                  | Required
         matrix:
           include:
             - target_os: ubuntu
-              target_os_version: '22.04'
             - target_os: ubuntu
               target_os_version: '24.04'
       permissions:

--- a/README/REUSABLE-TESTS-ORCA.md
+++ b/README/REUSABLE-TESTS-ORCA.md
@@ -25,19 +25,19 @@ To integrate this workflow into your pipeline:
 
 ### Inputs
 
-Name                | Description                                     | Required | Type   | Default
-------------------- | ----------------------------------------------- | -------- | ------ | -------
-`version`           | Greengage version (e.g., `6` or `7`)            | Yes      | String | -
-`target_os`         | Target operating system (e.g., `ubuntu`)        | Yes      | String | -
-`target_os_version` | Target OS version (e.g., ``, `24.04`)           | No      | String | -
-`python3`           | Python3 build argument (ignored)                | No       | String | `''`
-`ref`               | Branch or tag to checkout (e.g., `main`, `7.x`) | No       | String | `''`
+| Name                | Description                                       | Required | Type    | Default |
+|---------------------|---------------------------------------------------|----------|---------|---------|
+| `version`           | Greengage version (e.g., `6` or `7`)              | Yes      | String  | -       |
+| `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
+| `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
+| `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
+| `python3`           | Python3 build argument (ignored)                  | No       | String  | `''`    |
 
 ### Secrets
 
-Name         | Description                  | Required
------------- | ---------------------------- | --------
-`ghcr_token` | GitHub token for GHCR access | Yes
+|Name         | Description                  | Required|
+|------------ | ---------------------------- | --------|
+|`ghcr_token` | GitHub token for GHCR access | Yes     |
 
 ### Requirements
 

--- a/README/REUSABLE-TESTS-ORCA.md
+++ b/README/REUSABLE-TESTS-ORCA.md
@@ -29,7 +29,7 @@ Name                | Description                                     | Required
 ------------------- | ----------------------------------------------- | -------- | ------ | -------
 `version`           | Greengage version (e.g., `6` or `7`)            | Yes      | String | -
 `target_os`         | Target operating system (e.g., `ubuntu`)        | Yes      | String | -
-`target_os_version` | Target OS version (e.g., ``, `24.04`)           | Yes      | String | -
+`target_os_version` | Target OS version (e.g., ``, `24.04`)           | No      | String | -
 `python3`           | Python3 build argument (ignored)                | No       | String | `''`
 `ref`               | Branch or tag to checkout (e.g., `main`, `7.x`) | No       | String | `''`
 

--- a/README/REUSABLE-TESTS-REGRESSION.md
+++ b/README/REUSABLE-TESTS-REGRESSION.md
@@ -25,18 +25,19 @@ To integrate this workflow into your pipeline:
 
 ### Inputs
 
-Name                | Description                                              | Required | Type   | Default
-------------------- | -------------------------------------------------------- | -------- | ------ | -------
-`version`           | Greengage version (e.g., `6` or `7`)                     | Yes      | String | -
-`target_os`         | Target operating system (e.g., `ubuntu`)                 | Yes      | String | -
-`target_os_version` | Target OS version (e.g., ``, `24.04`)                    | No      | String | -
-`python3`           | Python3 build argument (ignored, kept for compatibility) | No       | String | `''`
+| Name                | Description                                       | Required | Type    | Default |
+|---------------------|---------------------------------------------------|----------|---------|---------|
+| `version`           | Greengage version (e.g., `6` or `7`)              | Yes      | String  | -       |
+| `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
+| `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
+| `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
+| `python3`           | Python3 build argument (ignored)                  | No       | String  | `''`    |
 
 ### Secrets
 
-Name         | Description                  | Required
------------- | ---------------------------- | --------
-`ghcr_token` | GitHub token for GHCR access | Yes
+|Name         | Description                  | Required|
+|------------ | ---------------------------- | --------|
+|`ghcr_token` | GitHub token for GHCR access | Yes     |
 
 ### Requirements
 

--- a/README/REUSABLE-TESTS-REGRESSION.md
+++ b/README/REUSABLE-TESTS-REGRESSION.md
@@ -29,7 +29,7 @@ Name                | Description                                              |
 ------------------- | -------------------------------------------------------- | -------- | ------ | -------
 `version`           | Greengage version (e.g., `6` or `7`)                     | Yes      | String | -
 `target_os`         | Target operating system (e.g., `ubuntu`)                 | Yes      | String | -
-`target_os_version` | Target OS version (e.g., ``, `24.04`)                    | Yes      | String | -
+`target_os_version` | Target OS version (e.g., ``, `24.04`)                    | No      | String | -
 `python3`           | Python3 build argument (ignored, kept for compatibility) | No       | String | `''`
 
 ### Secrets

--- a/README/REUSABLE-TESTS-REGRESSION.md
+++ b/README/REUSABLE-TESTS-REGRESSION.md
@@ -29,7 +29,7 @@ Name                | Description                                              |
 ------------------- | -------------------------------------------------------- | -------- | ------ | -------
 `version`           | Greengage version (e.g., `6` or `7`)                     | Yes      | String | -
 `target_os`         | Target operating system (e.g., `ubuntu`)                 | Yes      | String | -
-`target_os_version` | Target OS version (e.g., `22.04`, `24.04`)               | Yes      | String | -
+`target_os_version` | Target OS version (e.g., ``, `24.04`)                    | Yes      | String | -
 `python3`           | Python3 build argument (ignored, kept for compatibility) | No       | String | `''`
 
 ### Secrets
@@ -64,7 +64,6 @@ Name         | Description                  | Required
       with:
         version: 6
         target_os: ubuntu
-        target_os_version: '22.04'
       secrets:
         ghcr_token: ${{ secrets.GITHUB_TOKEN }}
   ```
@@ -81,7 +80,6 @@ Name         | Description                  | Required
         matrix:
           include:
             - target_os: ubuntu
-              target_os_version: '22.04'
             - target_os: ubuntu
               target_os_version: '24.04'
       permissions:

--- a/README/REUSABLE-TESTS-RESGROUP.md
+++ b/README/REUSABLE-TESTS-RESGROUP.md
@@ -47,7 +47,7 @@ Name                | Description                                               
 ------------------- | ---------------------------------------------------------------- | -------- | ------ | -------
 `version`           | Greengage version (e.g., `6` or `7`)                             | Yes      | String | -
 `target_os`         | Target operating system (e.g., `ubuntu`, `centos`, `rockylinux`) | Yes      | String | -
-`target_os_version` | Target OS version (e.g., `22.04`, `24.04`, `7`, `8`)             | Yes      | String | -
+`target_os_version` | Target OS version (e.g., ``, `24.04`, `7`, `8`)                  | Yes      | String | -
 `python3`           | Python3 build argument (ignored)                                 | No       | String | `''`
 
 ### Secrets
@@ -94,7 +94,6 @@ jobs:
       with:
         version: 7
         target_os: ubuntu
-        target_os_version: '22.04'
       secrets:
         ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -109,7 +108,6 @@ jobs:
         matrix:
           include:
             - target_os: ubuntu
-              target_os_version: '22.04'
             - target_os: ubuntu
               target_os_version: '24.04'
       permissions:

--- a/README/REUSABLE-TESTS-RESGROUP.md
+++ b/README/REUSABLE-TESTS-RESGROUP.md
@@ -43,18 +43,19 @@ To integrate this workflow into your pipeline:
 
 ### Inputs
 
-Name                | Description                                                      | Required | Type   | Default
-------------------- | ---------------------------------------------------------------- | -------- | ------ | -------
-`version`           | Greengage version (e.g., `6` or `7`)                             | Yes      | String | -
-`target_os`         | Target operating system (e.g., `ubuntu`, `centos`, `rockylinux`) | Yes      | String | -
-`target_os_version` | Target OS version (e.g., ``, `24.04`, `7`, `8`)                  | No      | String | -
-`python3`           | Python3 build argument (ignored)                                 | No       | String | `''`
+| Name                | Description                                       | Required | Type    | Default |
+|---------------------|---------------------------------------------------|----------|---------|---------|
+| `version`           | Greengage version (e.g., `6` or `7`)              | Yes      | String  | -       |
+| `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
+| `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
+| `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
+| `python3`           | Python3 build argument (ignored)                  | No       | String  | `''`    |
 
 ### Secrets
 
-Name         | Description                  | Required
------------- | ---------------------------- | --------
-`ghcr_token` | GitHub token for GHCR access | Yes
+|Name         | Description                  | Required|
+|------------ | ---------------------------- | --------|
+|`ghcr_token` | GitHub token for GHCR access | Yes     |
 
 ### Requirements
 

--- a/README/REUSABLE-TESTS-RESGROUP.md
+++ b/README/REUSABLE-TESTS-RESGROUP.md
@@ -47,7 +47,7 @@ Name                | Description                                               
 ------------------- | ---------------------------------------------------------------- | -------- | ------ | -------
 `version`           | Greengage version (e.g., `6` or `7`)                             | Yes      | String | -
 `target_os`         | Target operating system (e.g., `ubuntu`, `centos`, `rockylinux`) | Yes      | String | -
-`target_os_version` | Target OS version (e.g., ``, `24.04`, `7`, `8`)                  | Yes      | String | -
+`target_os_version` | Target OS version (e.g., ``, `24.04`, `7`, `8`)                  | No      | String | -
 `python3`           | Python3 build argument (ignored)                                 | No       | String | `''`
 
 ### Secrets

--- a/README/REUSABLE-UPLOAD.md
+++ b/README/REUSABLE-UPLOAD.md
@@ -18,59 +18,59 @@ The workflow processes a Docker image to retag and push it to GHCR and DockerHub
 
 1. **Authentication**:
 
-  - Login to GHCR is always mandatory.
-  - Login to DockerHub is conditional:
+   - Login to GHCR is always mandatory.
+   - Login to DockerHub is conditional:
 
-    - For repository `greengagedb/greengage`: mandatory (failure stops workflow)
-    - For other repositories: optional (failure is allowed)
+     - For repository `greengagedb/greengage`: mandatory (failure stops workflow)
+     - For other repositories: optional (failure is allowed)
 
 2. **Input Image**:
 
-  - The workflow expects an existing Docker image in GHCR with the format `ghcr.io/<repo>/ggdb<version>_<target_os><target_os_version>:<full-sha>`, where:
+   - The workflow expects an existing Docker image in GHCR with the format `ghcr.io/<repo>/ggdb<version>_<target_os><target_os_version>:<full-sha>`, where:
 
-    - `<repo>` is the repository name (`${{ github.repository }}`).
-    - `<version>` is the Greengage version (e.g., `6` or `7`), provided via the `version` input.
-    - `<target_os>` is the target operating system (e.g., `ubuntu`, `centos`), provided via the `target_os` input.
-    - `<target_os_version>` is the OS version (e.g., `22.04`, `24.04`, `7`), provided via the `target_os_version` input.
-    - `<full-sha>` is the full commit SHA (`${{ github.sha }}`) of the repository at the time of the build.
+     - `<repo>` is the repository name (`${{ github.repository }}`).
+     - `<version>` is the Greengage version (e.g., `6` or `7`), provided via the `version` input.
+     - `<target_os>` is the target operating system (e.g., `ubuntu`, `centos`), provided via the `target_os` input.
+     - `<target_os_version>` is the OS version (e.g., `22.04`, `24.04`, `7`), provided via the `target_os_version` input.
+     - `<full-sha>` is the full commit SHA (`${{ github.sha }}`) of the repository at the time of the build.
 
 3. **Tag Assignment**:
 
-  - The workflow assigns tags to the input image based on the event triggering the workflow:
+   - The workflow assigns tags to the input image based on the event triggering the workflow:
 
-    - **For tagged push events** (when `github.ref` matches `refs/tags/*`):
+     - **For tagged push events** (when `github.ref` matches `refs/tags/*`):
 
-      - The version tag is derived from the git tag using `git describe --tags --abbrev=0`.
-      - Slashes (`/`) in the tag are replaced with `_` to ensure a valid Docker tag.
-      - If no tag is found or the tag is invalid, the fallback tag `unknown` is used.
-      - The `latest` tag is assigned if this is the latest semantic version tag.
-      - Example: For a git tag `6.28.3`, the tags are `6.28.3` and possibly `latest`.
+       - The version tag is derived from the git tag using `git describe --tags --abbrev=0`.
+       - Slashes (`/`) in the tag are replaced with `_` to ensure a valid Docker tag.
+       - If no tag is found or the tag is invalid, the fallback tag `unknown` is used.
+       - The `latest` tag is assigned if this is the latest semantic version tag.
+       - Example: For a git tag `6.28.3`, the tags are `6.28.3` and possibly `latest`.
 
-    - **For push to a branch** (e.g., `main` or `7.x`):
+     - **For push to a branch** (e.g., `main` or `7.x`):
 
-      - No version tag is assigned. Developer's branch tags pushed via Build.
-      - The `latest` tag is assigned for GHCR.
-      - The `testing` tag is assigned for DockerHub when logged in.
+       - No version tag is assigned. Developer's branch tags pushed via Build.
+       - The `latest` tag is assigned for GHCR.
+       - The `testing` tag is assigned for DockerHub when logged in.
 
 4. **Tagging and Pushing**:
 
-  - For tagged pushes:
+   - For tagged pushes:
 
-    - The input image (`$GHCR_IMAGE:${{ github.sha }}`) is tagged with the version tag (`$GHCR_IMAGE:$TAG`) and pushed to GHCR.
-    - If the tag is the latest semantic version, it is also tagged as `latest` and pushed to GHCR.
-    - If DockerHub login was successful, the image is tagged with the version tag (`$DOCKERHUB_IMAGE:$TAG`) and pushed to DockerHub.
+     - The input image (`$GHCR_IMAGE:${{ github.sha }}`) is tagged with the version tag (`$GHCR_IMAGE:$TAG`) and pushed to GHCR.
+     - If the tag is the latest semantic version, it is also tagged as `latest` and pushed to GHCR.
+     - If DockerHub login was successful, the image is tagged with the version tag (`$DOCKERHUB_IMAGE:$TAG`) and pushed to DockerHub.
 
-  - For branch pushes:
+   - For branch pushes:
 
-    - The input image is tagged as `latest` (`$GHCR_IMAGE:latest`) and pushed to GHCR.
-    - If DockerHub login was successful, the image is tagged as `testing` (`$DOCKERHUB_IMAGE:testing`) and pushed to DockerHub.
+     - The input image is tagged as `latest` (`$GHCR_IMAGE:latest`) and pushed to GHCR.
+     - If DockerHub login was successful, the image is tagged as `testing` (`$DOCKERHUB_IMAGE:testing`) and pushed to DockerHub.
 
 5. **Failure Conditions**:
 
-  - If the input image does not exist in GHCR, the `docker pull` command will fail, causing the workflow to exit with an error.
-  - If the sanitized tag is invalid or empty (despite the `unknown` fallback), the `docker push` may fail if the tag does not conform to Docker's tag requirements.
-  - If `DOCKERHUB_USERNAME` or `DOCKERHUB_TOKEN` are missing, DockerHub login may fail, but pushes to GHCR proceed.
-  - For repository `greengagedb/greengage`, DockerHub login failure will stop the workflow.
+   - If the input image does not exist in GHCR, the `docker pull` command will fail, causing the workflow to exit with an error.
+   - If the sanitized tag is invalid or empty (despite the `unknown` fallback), the `docker push` may fail if the tag does not conform to Docker's tag requirements.
+   - If `DOCKERHUB_USERNAME` or `DOCKERHUB_TOKEN` are missing, DockerHub login may fail, but pushes to GHCR proceed.
+   - For repository `greengagedb/greengage`, DockerHub login failure will stop the workflow.
 
 ## Usage
 
@@ -82,20 +82,21 @@ To integrate this workflow into your pipeline:
 
 ### Inputs
 
-Name                | Description                                 | Required | Type   | Default
-------------------- | ------------------------------------------- | -------- | ------ | -------
-`version`           | Version derived from tag (e.g., `6` or `7`) | Yes      | String | -
-`target_os`         | Target operating system (e.g., `ubuntu`)    | Yes      | String | -
-`target_os_version` | Target OS version (e.g., ``, `24.04`)       | No      | String | -
-`python3`           | Python3 build argument (ignored)            | No       | String | `''`
+| Name                | Description                                       | Required | Type    | Default |
+|---------------------|---------------------------------------------------|----------|---------|---------|
+| `version`           | Greengage version (e.g., `6` or `7`)              | Yes      | String  | -       |
+| `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
+| `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
+| `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
+| `python3`           | Python3 build argument (ignored)                  | No       | String  | `''`    |
 
 ### Secrets
 
-Name                 | Description                           | Required
--------------------- | ------------------------------------- | --------
-`ghcr_token`         | GitHub token for GHCR access          | Yes
-`DOCKERHUB_USERNAME` | DockerHub username for authentication | No
-`DOCKERHUB_TOKEN`    | DockerHub token for authentication    | No
+|Name                  | Description                           | Required|
+|--------------------- | ------------------------------------- | --------|
+|`ghcr_token`          | GitHub token for GHCR access          | Yes     |
+| `DOCKERHUB_USERNAME` | DockerHub username for authentication | No      |
+| `DOCKERHUB_TOKEN`    | DockerHub token for authentication    | No      |
 
 ### Requirements
 

--- a/README/REUSABLE-UPLOAD.md
+++ b/README/REUSABLE-UPLOAD.md
@@ -86,7 +86,7 @@ Name                | Description                                 | Required | T
 ------------------- | ------------------------------------------- | -------- | ------ | -------
 `version`           | Version derived from tag (e.g., `6` or `7`) | Yes      | String | -
 `target_os`         | Target operating system (e.g., `ubuntu`)    | Yes      | String | -
-`target_os_version` | Target OS version (e.g., ``, `24.04`)       | Yes      | String | -
+`target_os_version` | Target OS version (e.g., ``, `24.04`)       | No      | String | -
 `python3`           | Python3 build argument (ignored)            | No       | String | `''`
 
 ### Secrets

--- a/README/REUSABLE-UPLOAD.md
+++ b/README/REUSABLE-UPLOAD.md
@@ -86,7 +86,7 @@ Name                | Description                                 | Required | T
 ------------------- | ------------------------------------------- | -------- | ------ | -------
 `version`           | Version derived from tag (e.g., `6` or `7`) | Yes      | String | -
 `target_os`         | Target operating system (e.g., `ubuntu`)    | Yes      | String | -
-`target_os_version` | Target OS version (e.g., `22.04`, `24.04`)  | Yes      | String | -
+`target_os_version` | Target OS version (e.g., ``, `24.04`)       | Yes      | String | -
 `python3`           | Python3 build argument (ignored)            | No       | String | `''`
 
 ### Secrets
@@ -136,7 +136,6 @@ Name                 | Description                           | Required
         matrix:
           include:
             - target_os: ubuntu
-              target_os_version: '22.04'
             - target_os: ubuntu
               target_os_version: '24.04'
       permissions:


### PR DESCRIPTION
## Detect '@skip' tag in Behave CI matrix generation (#47)

- Matrix generation now produces two separate arrays - `run_matrix`
  (features without `@skip`) and `skip_matrix` (features with `@skip`)
- Only `run_matrix` is passed to the `behave` job, so skipped features
  never enter the matrix
- Skipped features are listed in the Job Summary of `generate-matrix`
  for visibility
- `continue-on-error: true` added to the SQL dump fetch step as requested

Task: [CI-5599](https://tracker.yandex.ru/CI-5599)