### PR TITLE
CI-5597: Resgroup tests: switch optimizer matrix exception from 6.x to 7.x

### DIFF
--- a/.github/workflows/greengage-reusable-tests-resgroup.yml
+++ b/.github/workflows/greengage-reusable-tests-resgroup.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        optimizer: ${{ fromJson(inputs.version == '6' && '["postgres"]' || '["orca", "postgres"]') }}
+        optimizer: ${{ inputs.version == '7' && '["postgres", "orca"]' || '["postgres"]' }}
     permissions:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity


### PR DESCRIPTION
## Resgroup tests: switch optimizer matrix exception from 6.x to 7.x

With the introduction of 8.x (which also uses only postgres optimizer),
version 6.x is no longer the exclusive exception.
Version 7.x now becomes the special case that requires both postgres
and ORCA optimizers, while all other versions (6.x and 8.x) run only postgres.

Simplify matrix expression by removing redundant fromJson wrapper
and inverting condition logic for better readability.

Task: [CI-5597](https://tracker.yandex.ru/CI-5597)