### PR TITLE
CI-5646: Use Azure Ubuntu mirror in docker build

### DIFF
--- a/.github/workflows/greengage-reusable-build.yml
+++ b/.github/workflows/greengage-reusable-build.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Resolve Azure Ubuntu mirror
         run: echo "UBUNTU_MIRROR_IP=$(host azure.archive.ubuntu.com | awk '/has address/{print $NF; exit}')" >> $GITHUB_ENV
 
+      # Login to GitHub Container Registry for local PRs OR push
       - name: Login to GitHub Container Registry
         if: >
           github.event_name == 'push' ||

--- a/.github/workflows/greengage-reusable-build.yml
+++ b/.github/workflows/greengage-reusable-build.yml
@@ -56,7 +56,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Login to GitHub Container Registry for local PRs OR push
+      - name: Resolve Azure Ubuntu mirror
+        run: echo "UBUNTU_MIRROR_IP=$(host azure.archive.ubuntu.com | awk '/has address/{print $NF; exit}')" >> $GITHUB_ENV
+
       - name: Login to GitHub Container Registry
         if: >
           github.event_name == 'push' ||
@@ -71,6 +73,8 @@ jobs:
       # Build Docker intermediate image with commit SHA tag
       - name: Build Docker image
         run: docker build
+            --add-host=archive.ubuntu.com:$UBUNTU_MIRROR_IP
+            --add-host=security.ubuntu.com:$UBUNTU_MIRROR_IP
             --build-arg OS_VERSION
             --build-arg SKIP_UNITTESTS
             --tag ${IMAGE,,}:${{ github.sha }}

--- a/.github/workflows/greengage-reusable-build.yml
+++ b/.github/workflows/greengage-reusable-build.yml
@@ -53,12 +53,6 @@ jobs:
           fetch-tags: true  # Default 'false'
           filter: blob:none # without BLOBs
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Resolve Azure Ubuntu mirror
-        run: echo "UBUNTU_MIRROR_IP=$(host azure.archive.ubuntu.com | awk '/has address/{print $NF; exit}')" >> $GITHUB_ENV
-
       # Login to GitHub Container Registry for local PRs OR push
       - name: Login to GitHub Container Registry
         if: >
@@ -73,13 +67,18 @@ jobs:
 
       # Build Docker intermediate image with commit SHA tag
       - name: Build Docker image
-        run: docker build
-            --add-host=archive.ubuntu.com:$UBUNTU_MIRROR_IP
-            --add-host=security.ubuntu.com:$UBUNTU_MIRROR_IP
-            --build-arg OS_VERSION
-            --build-arg SKIP_UNITTESTS
-            --tag ${IMAGE,,}:${{ github.sha }}
-            -f ci/Dockerfile.${{ inputs.target_os }}
+        run: |
+          UBUNTU_MIRROR_IP=$(host azure.archive.ubuntu.com | awk '/has address/{print $NF; exit}')
+          ADD_HOST_ARGS=""
+          if curl -sf --max-time 5 "http://${UBUNTU_MIRROR_IP}/ubuntu/" > /dev/null; then
+            ADD_HOST_ARGS="--add-host=archive.ubuntu.com:${UBUNTU_MIRROR_IP} --add-host=security.ubuntu.com:${UBUNTU_MIRROR_IP}"
+          fi
+          docker build \
+            ${ADD_HOST_ARGS} \
+            --build-arg OS_VERSION \
+            --build-arg SKIP_UNITTESTS \
+            --tag ${IMAGE,,}:${{ github.sha }} \
+            -f ci/Dockerfile.${{ inputs.target_os }} \
             .
 
       # Push developer's and SHA tag image for internal PRs and pushes

--- a/.github/workflows/greengage-reusable-build.yml
+++ b/.github/workflows/greengage-reusable-build.yml
@@ -68,13 +68,11 @@ jobs:
       # Build Docker intermediate image with commit SHA tag
       - name: Build Docker image
         run: |
-          UBUNTU_MIRROR_IP=$(host azure.archive.ubuntu.com | awk '/has address/{print $NF; exit}')
-          ADD_HOST_ARGS=""
-          if curl -sf --max-time 5 "http://${UBUNTU_MIRROR_IP}/ubuntu/" > /dev/null; then
-            ADD_HOST_ARGS="--add-host=archive.ubuntu.com:${UBUNTU_MIRROR_IP} --add-host=security.ubuntu.com:${UBUNTU_MIRROR_IP}"
+          ubuntu_mirror_ip=$(host azure.archive.ubuntu.com | awk '/has address/{print $NF; exit}')
+          if curl -sf --max-time 5 "http://${ubuntu_mirror_ip}/ubuntu/" > /dev/null; then
+            docker_options="--add-host=archive.ubuntu.com:${ubuntu_mirror_ip} --add-host=security.ubuntu.com:${ubuntu_mirror_ip}"
           fi
-          docker build \
-            ${ADD_HOST_ARGS} \
+          docker build $docker_options \
             --build-arg OS_VERSION \
             --build-arg SKIP_UNITTESTS \
             --tag ${IMAGE,,}:${{ github.sha }} \

--- a/README/REUSABLE-BUILD.md
+++ b/README/REUSABLE-BUILD.md
@@ -40,7 +40,7 @@ To integrate this workflow into your pipeline:
 - **Dockerfile**: Ensure a Dockerfile exists at `ci/Dockerfile.<target_os>` (e.g., `ci/Dockerfile.ubuntu`). The `OS_VERSION` build argument is passed to the Dockerfile with a default value of `22.04` if `target_os_version` is not provided.
 - **Repository Access**: The workflow checks out the current branch of the repository specified in `github.repository`. For PRs, it uses `github.event.pull_request.head.sha`; otherwise, it uses `github.ref`.
 - **Disk Space**: The workflow uses the `greengagedb/greengage-ci/.github/actions/maximize-disk-space@v24` action to maximize available disk space before building.
-- **Docker Buildx**: The workflow uses `docker/setup-buildx-action@v3` to set up Docker Buildx for building images.
+- **Ubuntu mirror**: During build, `azure.archive.ubuntu.com` is resolved and injected via `--add-host` for `archive.ubuntu.com` and `security.ubuntu.com`. Falls back to default mirrors if unreachable.
 - **Caching**: The built image is saved as a `.tar` file and cached using `actions/cache/save@v4` with a key matching the image tag.
 
 ### Examples


### PR DESCRIPTION
## Use Azure Ubuntu mirror in docker build (#49)

Fix: drop buildx, redirect apt to Azure mirror when available

- Remove unused `docker/setup-buildx-action` step
- Resolve `azure.archive.ubuntu.com` IP at build time and
  inject via `--add-host` for `archive.ubuntu.com` and `security.ubuntu.com`
- Fall back to default mirrors if Azure mirror is unreachable
- Update README to reflect removed Buildx step and new mirror behaviour

Task: [CI-5646](https://tracker.yandex.ru/CI-5646)