### PR TITLE
CI-5678: Look for ubuntu24.04 SQL dump artifact on 6.x

### DIFF
--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -109,8 +109,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          artifact_name="sqldump_ggdb${{ inputs.version }}_${{ inputs.target_os }}"
-          artifact_archive_name="${{ inputs.target_os }}_postgres_sqldump.tar"
+          artifact_name="sqldump_ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.version == '6' && '24.04' || '' }}"
+          artifact_archive_name="${{ inputs.target_os }}${{ inputs.version == '6' && '24.04' || '' }}_postgres_sqldump.tar"
 
           run_ids=$(gh run list --workflow "Greengage SQL Dump" \
             --limit 100 \

--- a/.github/workflows/greengage-reusable-tests-regression.yml
+++ b/.github/workflows/greengage-reusable-tests-regression.yml
@@ -23,11 +23,6 @@ on:
         required: false
         type: string
         default: ''
-      python3:
-        description: 'Python3 build argument (ignored)'
-        required: false
-        type: string
-        default: ''
     secrets:
       ghcr_token:
         description: 'GitHub token for GHCR access'


### PR DESCRIPTION
## Look for ubuntu24.04 SQL dump artifact on ggdb6 (#51)

The `gpexpand` behave test was looking for `sqldump_ggdb6_ubuntu` artifact,
but the SQL dump workflow now generates `sqldump_ggdb6_ubuntu24.04` after
regression tests were fully switched to `ubuntu24`

- Fix `artifact_name` and `artifact_archive_name` to include `ubuntu24.04`
  suffix for `6.x`, keeping legacy empty suffix for `7.x`

Also removes unused python3 input from the regression reusable workflow
(no dedicated task - long unused, removed in passing).

Task: [CI-5678](https://tracker.yandex.ru/CI-5678)