### PR TITLE
CI-5243 Add sigar installation to package testing workflow

### DIFF
--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -92,32 +92,24 @@ jobs:
       - name: Start Docker container and install deb package
         run: |
           set -eux
-          docker run --rm -i \
-            -v ./deb-packages:/deb-packages \
-            "${TEST_DOCKER}" \
-            /bin/bash <<'EOF'
+      curl -fsSL https://greengagedb.org/repositories/gpg \
+        | sudo gpg --dearmor -o /etc/apt/keyrings/greengagedb.gpg
+      echo "deb [signed-by=/etc/apt/keyrings/greengagedb.gpg] \
+      https://greengagedb.org/repositories/ubuntu/22.04/x86_64 \
+      greengagedb main" \
+        | sudo tee /etc/apt/sources.list.d/greengagedb.list
 
-            export DEBIAN_FRONTEND=noninteractive
-
-            apt-get update
-            apt-get install curl gnupg ca-certificates -y
-
-            curl -fsSL greengagedb.org/repositories/gpg | gpg --dearmor -o /etc/apt/keyrings/greengagedb.gpg
-            echo "deb [signed-by=/etc/apt/keyrings/greengagedb.gpg] \
-            https://greengagedb.org/repositories/ubuntu/22.04/x86_64 \
-            greengagedb main" \
-            | tee /etc/apt/sources.list.d/greengagedb.list
-
-            apt-get update
-            apt-get install sigar -y
-
-            if ! apt-get install -y /deb-packages/*.deb; then
-              dpkg -i /deb-packages/*.deb
-            fi
-
-            apt-get install -f -y
-
-          EOF
+      docker run --rm \
+        -v ./deb-packages:/deb-packages \
+        -v /etc/apt/keyrings/greengagedb.gpg:/etc/apt/keyrings/greengagedb.gpg \
+        -v /etc/apt/sources.list.d/greengagedb.list:/etc/apt/sources.list.d/greengagedb.list \
+        "${TEST_DOCKER}" /bin/bash -c "
+          export DEBIAN_FRONTEND=noninteractive
+          # Disable SSL verification for https apt-repos
+          echo -en 'Acquire::https::Verify-Peer \"false\";\nAcquire::https::Verify-Host \"false\";\n' > /etc/apt/apt.conf.d/99no-verify-ssl
+          apt-get update
+          apt-get install -y /deb-packages/*.deb
+          dpkg -l greengage* sigar"
 
   # upload-to-release:
   #   if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -100,7 +100,7 @@ jobs:
           -v /etc/apt/keyrings/greengagedb.gpg:/etc/apt/keyrings/greengagedb.gpg \
           "${TEST_DOCKER}" /bin/bash -c "
           export DEBIAN_FRONTEND=noninteractive
-          apt-get update
+          apt-get update -o Acquire::https::Verify-Peer=false
           apt-get install -y ca-certificates
 
           echo "deb [signed-by=/etc/apt/keyrings/greengagedb.gpg] \

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -92,24 +92,25 @@ jobs:
       - name: Start Docker container and install deb package
         run: |
           set -eux
-      curl -fsSL https://greengagedb.org/repositories/gpg \
-        | sudo gpg --dearmor -o /etc/apt/keyrings/greengagedb.gpg
-      echo "deb [signed-by=/etc/apt/keyrings/greengagedb.gpg] \
-      https://greengagedb.org/repositories/ubuntu/22.04/x86_64 \
-      greengagedb main" \
-        | sudo tee /etc/apt/sources.list.d/greengagedb.list
+          curl -fsSL https://greengagedb.org/repositories/gpg \
+          | sudo gpg --dearmor -o /etc/apt/keyrings/greengagedb.gpg
 
-      docker run --rm \
-        -v ./deb-packages:/deb-packages \
-        -v /etc/apt/keyrings/greengagedb.gpg:/etc/apt/keyrings/greengagedb.gpg \
-        -v /etc/apt/sources.list.d/greengagedb.list:/etc/apt/sources.list.d/greengagedb.list \
-        "${TEST_DOCKER}" /bin/bash -c "
+          docker run --rm \
+          -v ./deb-packages:/deb-packages \
+          -v /etc/apt/keyrings/greengagedb.gpg:/etc/apt/keyrings/greengagedb.gpg \
+          "${TEST_DOCKER}" /bin/bash -c "
           export DEBIAN_FRONTEND=noninteractive
-          # Disable SSL verification for https apt-repos
-          echo -en 'Acquire::https::Verify-Peer \"false\";\nAcquire::https::Verify-Host \"false\";\n' > /etc/apt/apt.conf.d/99no-verify-ssl
+          apt-get update
+          apt-get install -y ca-certificates
+
+          echo "deb [signed-by=/etc/apt/keyrings/greengagedb.gpg] \
+          https://greengagedb.org/repositories/ubuntu/22.04/x86_64 \
+          greengagedb main" \
+          | tee /etc/apt/sources.list.d/greengagedb.list
+
           apt-get update
           apt-get install -y /deb-packages/*.deb
-          dpkg -l greengage* sigar"
+          dpkg -l greengage* sigar ca-certificates"
 
   # upload-to-release:
   #   if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -92,12 +92,32 @@ jobs:
       - name: Start Docker container and install deb package
         run: |
           set -eux
-          docker run --rm -v ./deb-packages:/deb-packages \
-            "${TEST_DOCKER}" /bin/bash -c "\
-              export DEBIAN_FRONTEND=noninteractive && \
-              apt-get update && \
-              { apt-get install -y /deb-packages/*.deb 2>&1 || dpkg -i /deb-packages/*.deb 2>&1; } && \
-              apt-get install -f -y"
+          docker run --rm -i \
+            -v ./deb-packages:/deb-packages \
+            "${TEST_DOCKER}" \
+            /bin/bash <<'EOF'
+
+            export DEBIAN_FRONTEND=noninteractive
+
+            apt-get update
+            apt-get install curl gnupg ca-certificates -y
+
+            curl -fsSL greengagedb.org/repositories/gpg | gpg --dearmor -o /etc/apt/keyrings/greengagedb.gpg
+            echo "deb [signed-by=/etc/apt/keyrings/greengagedb.gpg] \
+            https://greengagedb.org/repositories/ubuntu/22.04/x86_64 \
+            greengagedb main" \
+            | tee /etc/apt/sources.list.d/greengagedb.list
+
+            apt-get update
+            apt-get install sigar -y
+
+            if ! apt-get install -y /deb-packages/*.deb; then
+              dpkg -i /deb-packages/*.deb
+            fi
+
+            apt-get install -f -y
+
+          EOF
 
   # upload-to-release:
   #   if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Add sigar installation to package testing (#53)

We should provide sigar as dependency for greengage6 package.
To test greengage6 installation we should have sigar to be installed
inside testing container.

Tests: https://github.com/uaqq/greengage/actions/runs/26187023157/job/77048590700

Task: CI-5243