### PR TITLE
CI-5720: CI script names and paths parameterize

### DIFF
--- a/.github/workflows/greengage-reusable-build.yml
+++ b/.github/workflows/greengage-reusable-build.yml
@@ -81,7 +81,7 @@ jobs:
             --build-arg OS_VERSION \
             --build-arg SKIP_UNITTESTS \
             --tag ${IMAGE,,}:${{ github.sha }} \
-            -f ${{ ci_path }}/Dockerfile.${{ inputs.target_os }} \
+            -f ${{ inputs.ci_path }}/Dockerfile.${{ inputs.target_os }} \
             .
 
       # Push developer's and SHA tag image for internal PRs and pushes

--- a/.github/workflows/greengage-reusable-build.yml
+++ b/.github/workflows/greengage-reusable-build.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: ''
+      ci_path:
+        description: 'Path to CI directory'
+        required: false
+        type: string
+        default: 'ci'
     secrets:
       ghcr_token:
         description: 'GitHub token for GHCR access'
@@ -76,7 +81,7 @@ jobs:
             --build-arg OS_VERSION \
             --build-arg SKIP_UNITTESTS \
             --tag ${IMAGE,,}:${{ github.sha }} \
-            -f ci/Dockerfile.${{ inputs.target_os }} \
+            -f ${{ ci_path }}/Dockerfile.${{ inputs.target_os }} \
             .
 
       # Push developer's and SHA tag image for internal PRs and pushes

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -22,11 +22,11 @@ on:
         required: false
         type: string
         default: ''
-      python3:
-        description: 'Python3 build argument (ignored)'
+      ci_path:
+        description: 'Path to CI directory'
         required: false
         type: string
-        default: ''
+        default: 'ci'
     secrets:
       ghcr_token:
         description: 'GitHub token for GHCR access'
@@ -138,7 +138,7 @@ jobs:
           IMAGE: ghcr.io/${{ github.repository }}/ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}:${{ github.sha }}
         run: |
           export IMAGE=${IMAGE,,}
-          bash ci/scripts/run_behave_tests.bash ${{ matrix.feature }}
+          bash ${{ ci_path }}/scripts/run_behave_tests.bash ${{ matrix.feature }}
 
       - name: Collect logs ${{ matrix.feature }}
         if: always()

--- a/.github/workflows/greengage-reusable-tests-behave.yml
+++ b/.github/workflows/greengage-reusable-tests-behave.yml
@@ -138,7 +138,7 @@ jobs:
           IMAGE: ghcr.io/${{ github.repository }}/ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}:${{ github.sha }}
         run: |
           export IMAGE=${IMAGE,,}
-          bash ${{ ci_path }}/scripts/run_behave_tests.bash ${{ matrix.feature }}
+          bash ${{ inputs.ci_path }}/scripts/run_behave_tests.bash ${{ matrix.feature }}
 
       - name: Collect logs ${{ matrix.feature }}
         if: always()

--- a/.github/workflows/greengage-reusable-tests-jit.yml
+++ b/.github/workflows/greengage-reusable-tests-jit.yml
@@ -21,11 +21,6 @@ on:
         required: false
         type: string
         default: ''
-      python3:
-        description: 'Python3 build argument (ignored)'
-        required: false
-        type: string
-        default: ''
     secrets:
       ghcr_token:
         description: 'GitHub token for GHCR access'

--- a/.github/workflows/greengage-reusable-tests-orca.yml
+++ b/.github/workflows/greengage-reusable-tests-orca.yml
@@ -22,11 +22,6 @@ on:
         required: false
         type: string
         default: ''
-      python3:
-        description: 'Python3 build argument (ignored)'
-        required: false
-        type: string
-        default: ''
     secrets:
       ghcr_token:
         description: 'GitHub token for GHCR access'

--- a/.github/workflows/greengage-reusable-tests-orca.yml
+++ b/.github/workflows/greengage-reusable-tests-orca.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: ''
+      ci_path:
+        description: 'Path to CI directory'
+        required: false
+        type: string
+        default: 'ci'
     secrets:
       ghcr_token:
         description: 'GitHub token for GHCR access'
@@ -55,7 +60,7 @@ jobs:
       # Run ORCA Linter
       - name: ORCA Linter
         run: |
-          docker build -t orca-linter:test -f ci/Dockerfile.linter .
+          docker build -t orca-linter:test -f ${{ inputs.ci_path }}/Dockerfile.linter .
           docker run      orca-linter:test
 
       # Run ORCA Unit test using the passed image tag

--- a/.github/workflows/greengage-reusable-tests-resgroup.yml
+++ b/.github/workflows/greengage-reusable-tests-resgroup.yml
@@ -18,11 +18,11 @@ on:
         required: false
         type: string
         default: ''
-      python3:
-        description: 'Python3 build argument (ignored)'
+      ci_path:
+        description: 'Path to CI directory'
         required: false
         type: string
-        default: ''
+        default: 'ci'
     secrets:
       ghcr_token:
         description: 'GitHub token for GHCR access'
@@ -233,7 +233,7 @@ jobs:
         run: |
           ${SSH_COMMAND} "cd /home/gpadmin \
                           && export \$(cat .env.tests | xargs) \
-                          && bash ci/scripts/run_resgroup_test.bash"
+                          && bash ${{ ci_path }}/scripts/run_resgroup_test.bash"
 
       - name: Collect logs
         if: always()

--- a/.github/workflows/greengage-reusable-tests-resgroup.yml
+++ b/.github/workflows/greengage-reusable-tests-resgroup.yml
@@ -233,7 +233,7 @@ jobs:
         run: |
           ${SSH_COMMAND} "cd /home/gpadmin \
                           && export \$(cat .env.tests | xargs) \
-                          && bash ${{ ci_path }}/scripts/run_resgroup_test.bash"
+                          && bash ${{ inputs.ci_path }}/scripts/run_resgroup_test.bash"
 
       - name: Collect logs
         if: always()

--- a/.github/workflows/greengage-reusable-tests-resgroup.yml
+++ b/.github/workflows/greengage-reusable-tests-resgroup.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        optimizer: ${{ inputs.version == '7' && '["postgres", "orca"]' || '["postgres"]' }}
+        optimizer: ${{ fromJson(inputs.version == '7' && '["postgres", "orca"]' || '["postgres"]') }}
     permissions:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity

--- a/.github/workflows/greengage-reusable-upload.yml
+++ b/.github/workflows/greengage-reusable-upload.yml
@@ -17,11 +17,6 @@ on:
         required: false
         type: string
         default: ''
-      python3:
-        description: 'Python3 build argument'
-        required: false
-        type: string
-        default: ''
     secrets:
       ghcr_token:
         description: 'GitHub token for GHCR access'

--- a/README/REUSABLE-BUILD.md
+++ b/README/REUSABLE-BUILD.md
@@ -26,6 +26,7 @@ To integrate this workflow into your pipeline:
 | `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
 | `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
 | `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
+| `ci_path`           | Path to CI directory scripts and Dockerfiles      | No       | String  | `ci`    |
 
 ### Secrets
 

--- a/README/REUSABLE-TESTS-BEHAVE.md
+++ b/README/REUSABLE-TESTS-BEHAVE.md
@@ -44,6 +44,7 @@ To integrate this workflow into your pipeline:
 | `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
 | `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
 | `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
+| `ci_path`           | Path to CI directory scripts and Dockerfiles      | No       | String  | `ci`    |
 
 ### Secrets
 

--- a/README/REUSABLE-TESTS-BEHAVE.md
+++ b/README/REUSABLE-TESTS-BEHAVE.md
@@ -44,7 +44,6 @@ To integrate this workflow into your pipeline:
 | `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
 | `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
 | `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
-| `python3`           | Python3 build argument (ignored)                  | No       | String  | `''`    |
 
 ### Secrets
 
@@ -76,7 +75,6 @@ To integrate this workflow into your pipeline:
       with:
         version: 7
         target_os: ubuntu
-        python3: ''
       secrets:
         ghcr_token: ${{ secrets.GITHUB_TOKEN }}
   ```

--- a/README/REUSABLE-TESTS-ORCA.md
+++ b/README/REUSABLE-TESTS-ORCA.md
@@ -31,6 +31,7 @@ To integrate this workflow into your pipeline:
 | `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
 | `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
 | `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
+| `ci_path`           | Path to CI directory scripts and Dockerfiles      | No       | String  | `ci`    |
 
 ### Secrets
 

--- a/README/REUSABLE-TESTS-ORCA.md
+++ b/README/REUSABLE-TESTS-ORCA.md
@@ -31,7 +31,6 @@ To integrate this workflow into your pipeline:
 | `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
 | `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
 | `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
-| `python3`           | Python3 build argument (ignored)                  | No       | String  | `''`    |
 
 ### Secrets
 
@@ -62,7 +61,6 @@ To integrate this workflow into your pipeline:
       with:
         version: 7
         target_os: ubuntu
-        python3: ''
       secrets:
         ghcr_token: ${{ secrets.GITHUB_TOKEN }}
   ```

--- a/README/REUSABLE-TESTS-REGRESSION.md
+++ b/README/REUSABLE-TESTS-REGRESSION.md
@@ -31,7 +31,6 @@ To integrate this workflow into your pipeline:
 | `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
 | `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
 | `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
-| `python3`           | Python3 build argument (ignored)                  | No       | String  | `''`    |
 
 ### Secrets
 

--- a/README/REUSABLE-TESTS-RESGROUP.md
+++ b/README/REUSABLE-TESTS-RESGROUP.md
@@ -49,7 +49,6 @@ To integrate this workflow into your pipeline:
 | `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
 | `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
 | `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
-| `python3`           | Python3 build argument (ignored)                  | No       | String  | `''`    |
 
 ### Secrets
 

--- a/README/REUSABLE-TESTS-RESGROUP.md
+++ b/README/REUSABLE-TESTS-RESGROUP.md
@@ -49,6 +49,7 @@ To integrate this workflow into your pipeline:
 | `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
 | `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
 | `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
+| `ci_path`           | Path to CI directory scripts and Dockerfiles      | No       | String  | `ci`    |
 
 ### Secrets
 

--- a/README/REUSABLE-UPLOAD.md
+++ b/README/REUSABLE-UPLOAD.md
@@ -88,7 +88,6 @@ To integrate this workflow into your pipeline:
 | `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
 | `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
 | `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
-| `python3`           | Python3 build argument (ignored)                  | No       | String  | `''`    |
 
 ### Secrets
 
@@ -120,7 +119,6 @@ To integrate this workflow into your pipeline:
         version: 7
         target_os: ubuntu
         target_os_version: ''
-        python3: ''
       secrets:
         ghcr_token: ${{ secrets.GITHUB_TOKEN }}
         DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## CI script names and paths parameterize

### Backward Compatibility

No breaking changes - `ci_path` defaults to `ci`, preserving existing behaviour.
The removed `python3` parameter was already a no-op.

### Summary

Introduces a `ci_path` input parameter across reusable workflows to allow callers to specify a custom path to CI scripts and Dockerfiles, replacing the previously hardcoded `ci/` prefix. Also removes the deprecated `python3` parameter that was already ignored.

### Changes

New `ci_path` input parameter (default: `ci`) added to:
- `greengage-reusable-build.yml` — used in `docker build -f` for the target OS Dockerfile
- `greengage-reusable-tests-behave.yml` — used in `run_behave_tests.bash` invocation
- `greengage-reusable-tests-orca.yml` — used in `docker build -f` for the linter Dockerfile
- `greengage-reusable-tests-resgroup.yml` — used in `run_resgroup_test.bash` invocation

Removed deprecated `python3` parameter from:
- `greengage-reusable-tests-behave.yml`
- `greengage-reusable-tests-jit.yml`
- `greengage-reusable-tests-orca.yml`
- `greengage-reusable-tests-resgroup.yml`
- `greengage-reusable-upload.yml`

README docs updated to reflect parameter changes across all affected workflows.

Task; [CI-5720](https://tracker.yandex.ru/CI-5720)