### PR TITLE
 CI-5741: Broken regress tests

### DIFF
--- a/.github/workflows/greengage-reusable-tests-resgroup.yml
+++ b/.github/workflows/greengage-reusable-tests-resgroup.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        optimizer: ${{ inputs.version == '7' && '["postgres", "orca"]' || '["postgres"]' }}
+        optimizer: ${{ fromJson(inputs.version == '7' && '["postgres", "orca"]' || '["postgres"]') }}
     permissions:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity


### PR DESCRIPTION
## Broken regress tests (#55)

### Cause - breaking changes in `greengage-reusable-tests-resgroup.yml`
```diff
      matrix:
-          optimizer: ${{ fromJson(inputs.version == '6' && '["postgres"]' || '["orca", "postgres"]') }}
+          optimizer: ${{ inputs.version == '7' && '["postgres", "orca"]' || '["postgres"]' }}
```

- fix(resgroup): return fromJson function to matrix defenition

Task:  CI-5741