### PR TITLE
CI-5753: Test deploy of deb-packages does not working

### DIFF
--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -112,17 +112,3 @@ jobs:
           apt-get install -y /deb-packages/*.deb
           dpkg -l greengage* sigar ca-certificates"
 
-  # upload-to-release:
-  #   if: startsWith(github.ref, 'refs/tags/')
-  #   needs: [build-deb, test-docker]
-  #   runs-on: ubuntu-24.04
-  #   permissions:
-  #     contents: write  # Required for release creation
-  #   steps:
-  #     - name: Upload packages to release
-  #       uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v19
-  #       with:
-  #         version: ${{ inputs.version }}    # optional, defaults empty
-  #         artifact_name: deb-packages       # optional, defaults to Packages
-  #         package_name: greengage           # optional, defaults to repo name
-  #         extensions: "deb ddeb"            # optional, space-separated list of extensions

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -103,12 +103,11 @@ jobs:
           apt-get update -o Acquire::https::Verify-Peer=false
           apt-get install -y ca-certificates
 
-          echo "deb [signed-by=/etc/apt/keyrings/greengagedb.gpg] \
+          echo 'deb [signed-by=/etc/apt/keyrings/greengagedb.gpg] \
           https://greengagedb.org/repositories/ubuntu/22.04/x86_64 \
-          greengagedb main" \
+          greengagedb main' \
           | tee /etc/apt/sources.list.d/greengagedb.list
 
           apt-get update
           apt-get install -y /deb-packages/*.deb
           dpkg -l greengage* sigar ca-certificates"
-


### PR DESCRIPTION
## Test deploy of deb-packages does not working

- [upd(package): remove commented upload-to-release](https://github.com/GreengageDB/greengage-ci/commit/47cd35a2bae4d43c09aab236b98f7ad8569238ea)
- [fix(package): replace double-quotas to single-quotas](https://github.com/GreengageDB/greengage-ci/commit/5b56e1c636d21b954b3815f0e845f1ed471d00fd)

Task: [CI-5753](https://tracker.yandex.ru/CI-5753)