### PR TITLE
add ubuntu 24.04 release target and make deb artifact names OS-specific

### DIFF
--- a/.github/actions/upload-pkgs-to-release/README.md
+++ b/.github/actions/upload-pkgs-to-release/README.md
@@ -8,33 +8,36 @@ This composite GitHub Action orchestrates the package release process by coordin
 
 1. **Wait for Package Building Workflow Completion**
 
-  - Polls the specified package generation workflow (`Greengage CI` by default)
-  - Verifies the workflow completed successfully for the exact commit and tag
-  - Provides configurable timeout (default: 4 hours) and polling interval (default: 60 seconds)
+   - Polls the specified package generation workflow (`Greengage CI` by default)
+   - Verifies the workflow completed successfully for the exact commit and tag
+   - Provides configurable timeout (default: 4 hours) and polling interval (default: 60 seconds)
 
 2. **Restore Built Packages from Cache**
 
-  - Retrieves packages from GitHub Actions cache using commit SHA as key
-  - Cache key format: `{artifact_name}-{commit_sha}`
+   - Retrieves packages from GitHub Actions cache using the explicit cache key passed by the caller
+   - Cache key format: `{package_dir}-{target_os}{target_os_version}-{commit_sha}`
 
 3. **Create Release if Needed**
 
-  - Creates GitHub release when `create_force` is specified and release doesn't exist
-  - Includes build metadata (commit SHA, workflow run ID) in release notes
+   - Creates GitHub release when `create_force` is specified and release doesn't exist
+   - Includes build metadata (commit SHA, workflow run ID) in release notes
 
 4. **Upload Packages with Original Names**
 
-  - Uploads packages to release preserving their original filenames
-  - Optional overwrite with `clobber` flag
+   - Uploads packages to release preserving their original filenames
+   - Optional overwrite with `clobber` flag
 
 ## Inputs
 
 Name                   | Required | Default        | Description
 ---------------------- | -------- | -------------- | ----------------------------------------------------------------
-`artifact_name`        | no       | `Packages`     | Cache key prefix for artifact restoration
-`release_name`         | no       | current tag    | Target release name (defaults to tag)
-`extensions`           | no       | `deb ddeb rpm` | Space-separated package extensions
-`create_force`         | no       | empty          | Force release creation if missing
+`cache_key`            | **yes**  |                | Full cache key used to restore built packages
+`package_dir`          | no       | `Packages`     | Local directory name where cache is restored (must match the build workflow)
+`package_name`         | no       | repo name      | Base package name for release notes
+`release_name`         | no       | current tag    | Target release name (defaults to current tag)
+`version`              | no       | empty          | Version string appended to package name in release notes
+`extensions`           | no       | `deb ddeb rpm` | Space-separated list of package file extensions to upload
+`create_force`         | no       | empty          | Force release creation if it doesn't exist
 `clobber`              | no       | `false`        | Overwrite existing release assets
 `ci_wait_timeout`      | no       | `14400`        | Timeout in seconds to wait for CI workflow (4 hours)
 `ci_poll_interval`     | no       | `60`           | Poll interval in seconds to check CI workflow status
@@ -45,6 +48,7 @@ Name                   | Required | Default        | Description
 - **Workflow Coordination**: Ensures package building completes successfully before release upload
 - **Build Status Verification**: Uses GitHub CLI to confirm successful build for specific commit/tag
 - **Cache-based Artifact Transfer**: Reliable package transfer between workflows via GitHub Actions cache
+- **Explicit Cache Keys**: Caller constructs and passes the cache key, keeping naming conventions in the calling workflow
 - **Configurable Timeouts**: Adjustable wait times for CI workflow completion
 - **Manual Recovery Flow**: Clear instructions when cache restoration fails
 
@@ -61,20 +65,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - artifact_name: deb-packages
-          extensions:    deb ddeb
-        - artifact_name: rpm-packages
-          extensions:    rpm
+        - version: 6
+          target_os: ubuntu
+          target_os_version: '22.04'
+          extensions:  deb ddeb
+          package_dir: deb-packages
+        - version: 6
+          target_os: ubuntu
+          target_os_version: '24.04'
+          extensions:  deb ddeb
+          package_dir: deb-packages
     runs-on: ubuntu-24.04
     permissions:
       contents: write
       actions: read
     steps:
       - name: Upload packages to release
-        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v10
+        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v38
         with:
-          extensions: ${{ matrix.extensions }}
-          artifact_name: ${{ matrix.artifact_name }}
+          version:     ${{ matrix.version }}
+          extensions:  ${{ matrix.extensions }}
+          package_dir: ${{ matrix.package_dir }}
+          cache_key:   ${{ matrix.package_dir }}-${{ matrix.target_os }}${{ matrix.target_os_version }}-${{ github.sha }}
 ```
 
 ## How It Works: Wait for Package Building
@@ -83,20 +95,20 @@ The action waits for the **package generation workflow** to complete before proc
 
 1. **Identifies the correct workflow run** by filtering on:
 
-  - Commit SHA (same as current release)
-  - Event type (`push`)
-  - Branch/tag name (release tag)
+   - Commit SHA (same as current release)
+   - Event type (`push`)
+   - Branch/tag name (release tag)
 
 2. **Monitors workflow status** until:
 
-  - **Success**: Proceeds with cache restoration and upload
-  - **Failure**: Exits with error and link to failed run
-  - **Timeout**: Exits after specified wait time
+   - **Success**: Proceeds with cache restoration and upload
+   - **Failure**: Exits with error and link to failed run
+   - **Timeout**: Exits after specified wait time
 
 3. **Requires specific permissions**:
 
-  - `contents: write` for release operations
-  - GitHub token with access to workflow run information
+   - `contents: write` for release operations
+   - GitHub token with access to workflow run information
 
 ## Error Handling
 
@@ -113,20 +125,22 @@ For this action to work correctly, the package building workflow must:
 
 1. **Use the same commit SHA** as the release workflow
 2. **Be triggered by push events** to the release tag
-3. **Store artifacts in cache** with key format: `{artifact_name}-{commit_sha}`
-4. **Complete successfully** before the release workflow proceeds
+3. **Store packages in cache** with key format: `{package_dir}-{target_os}{target_os_version}-{commit_sha}`
+4. **Use unique cache keys per OS/version** when building for multiple targets in a matrix
+5. **Complete successfully** before the release workflow proceeds
 
 ## Technical Implementation
 
 - **GitHub CLI Filtering**: Uses `gh run list --jq` with precise filtering to find the correct workflow run
-- **Cache Key Strategy**: Commit-based keys ensure artifact consistency
+- **Explicit Cache Key**: Caller passes the full `cache_key`; action does not construct it internally, keeping naming conventions co-located with the build matrix
 - **Package Validation**: Verifies exactly one file per extension before upload
-- **Original Filename Preservation**: Files are uploaded with their original names from the artifact
+- **Original Filename Preservation**: Files are uploaded with their original names from the cache
 - **Release Metadata**: Includes build provenance in release notes
 
 ## Notes
 
+- **Cache Key Convention**: The key must match exactly what the build workflow saves. Recommended format: `{package_dir}-{target_os}{target_os_version}-{github.sha}`
 - **Workflow Names**: Ensure `workflow_for_waiting` matches the exact name of your package building workflow
 - **Permissions**: Requires `GH_TOKEN` with `actions:read` and `contents:write` scopes
 - **Concurrency**: Consider using concurrency groups to prevent race conditions between workflows
-- **Cache Expiration**: GitHub Actions cache has retention policies; consider artifact fallback for long-term storage
+- **Cache Expiration**: GitHub Actions cache expires after 7 days; ensure releases are published within this window after the build

--- a/.github/actions/upload-pkgs-to-release/action.yaml
+++ b/.github/actions/upload-pkgs-to-release/action.yaml
@@ -2,8 +2,11 @@ name: Upload Packages to GitHub Release
 description: "Create or update a GitHub release and upload packages with fixed names"
 
 inputs:
-  cache_key:
-    description: 'Cache key for extract artifact'
+  target_os:
+    description: 'Target OS (e.g. ubuntu)'
+    required: true
+  target_os_version:
+    description: 'Target OS version (e.g. 22.04)'
     required: true
   package_dir:
     description: 'Local directory where cached packages are restored'
@@ -75,7 +78,7 @@ runs:
         while true; do
           elapsed=$(($(date +%s) - start_time))
           remaining=$((MAX_WAIT_SECONDS - elapsed))
-          
+
           if [ $remaining -le 0 ]; then
             echo "ERROR: Timeout waiting for CI workflow (waited ${MAX_WAIT_SECONDS}s)"
             exit 1
@@ -85,8 +88,8 @@ runs:
             --json conclusion,headSha,event,headBranch,url,status \
             --jq '
               map(select(
-                .headSha == "'"${{ github.sha }}"'" and 
-                .event == "push" and 
+                .headSha == "'"${{ github.sha }}"'" and
+                .event == "push" and
                 .headBranch == "'"${{ github.event.release.tag_name }}"'"
               )) |
               .[0]
@@ -122,8 +125,8 @@ runs:
       uses: actions/cache/restore@v4
       id: cache-restore
       with:
-        key:  ${{ inputs.cache_key }}
         path: ${{ inputs.package_dir }}
+        key:  ${{ inputs.package_dir }}-${{ inputs.target_os }}${{ inputs.target_os_version }}-${{ github.sha }}
 
     - name: Handle cache miss or restore failure
       if: steps.cache-restore.outputs.cache-hit != 'true'
@@ -186,6 +189,7 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
         RELEASE_NAME: ${{ inputs.release_name }}
+        REVISION: ${{ inputs.target_os }}${{ inputs.target_os_version }}
       run: |
         RELEASE_NAME=${RELEASE_NAME:-${GITHUB_REF#refs/tags/}}
 
@@ -203,8 +207,14 @@ runs:
             exit 1
           fi
 
-          echo "Uploading ${files[0]}"
-          gh release upload "$RELEASE_NAME" "${files[0]}" ${{ inputs.clobber == 'true' && '--clobber' || '' }} || not_uploaded=${not_uploaded:+$not_uploaded, }$ext
+          f="${files[0]}"
+          base="${f%.$ext}"
+          arch="${base##*_}"
+          mv ${base%_$arch}{,~${REVISION}}_${arch}.${ext}
+          f="${base%_$arch}~${REVISION}_${arch}.${ext}"
+
+          echo "Uploading $f"
+          gh release upload "$RELEASE_NAME" "$f" ${{ inputs.clobber == 'true' && '--clobber' || '' }} || not_uploaded=${not_uploaded:+$not_uploaded, }$ext
         done
         if [ -n "$not_uploaded" ] ; then
           echo "The following extension(s) are not uploaded: $not_uploaded"

--- a/.github/actions/upload-pkgs-to-release/action.yaml
+++ b/.github/actions/upload-pkgs-to-release/action.yaml
@@ -2,8 +2,11 @@ name: Upload Packages to GitHub Release
 description: "Create or update a GitHub release and upload packages with fixed names"
 
 inputs:
-  artifact_name:
-    description: 'Artifact name for download'
+  cache_key:
+    description: 'Cache key for extract artifact'
+    required: true
+  package_dir:
+    description: 'Local directory where cached packages are restored'
     required: false
     default: 'Packages'
   package_name:
@@ -119,8 +122,8 @@ runs:
       uses: actions/cache/restore@v4
       id: cache-restore
       with:
-        path: ${{ inputs.artifact_name }}
-        key:  ${{ inputs.artifact_name }}-${{ github.sha }}
+        key:  ${{ inputs.cache_key }}
+        path: ${{ inputs.package_dir }}
 
     - name: Handle cache miss or restore failure
       if: steps.cache-restore.outputs.cache-hit != 'true'
@@ -132,7 +135,7 @@ runs:
 
     - name: List downloaded files
       shell: bash
-      run: find "${{ inputs.artifact_name }}" -type f
+      run: find "${{ inputs.package_dir }}" -type f
 
     - name: Create release if not exists
       if: inputs.create_force != ''
@@ -194,7 +197,7 @@ runs:
         shopt -s nullglob
 
         for ext in ${{ inputs.extensions }}; do
-          files=("${{ inputs.artifact_name }}"/*.$ext)
+          files=("${{ inputs.package_dir }}"/*.$ext)
           if [ ${#files[@]} -ne 1 ]; then
             echo "Expected exactly one *.$ext file, found ${#files[@]}"
             exit 1

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -68,14 +68,14 @@ jobs:
       - name: Upload Debian artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: deb-packages
+          name: deb-packages-${{ inputs.target_os }}${{ inputs.target_os_version || '22.04' }}
           path: deb-packages
 
       - name: Cache Debian artifacts
         uses: actions/cache/save@v4
         with:
           path: deb-packages
-          key: deb-packages-${{ github.sha }}
+          key:  deb-packages-${{ inputs.target_os }}${{ inputs.target_os_version || '22.04' }}-${{ github.sha }}
 
   test-docker:
     if: inputs.test_docker != ''
@@ -87,7 +87,7 @@ jobs:
       - name: Download deb artifacts
         uses: actions/download-artifact@v4
         with:
-          name: deb-packages
+          name: deb-packages-${{ inputs.target_os }}${{ inputs.target_os_version || '22.04' }}
           path: deb-packages
       - name: Start Docker container and install deb package
         run: |

--- a/.github/workflows/greengage-sync-packages.yml
+++ b/.github/workflows/greengage-sync-packages.yml
@@ -49,7 +49,7 @@ jobs:
           source_repo:           ${{ env.GREENGAGE_REPO }}
           release_tag:           ${{ needs.check-releases.outputs.greengage_tag }}
           ci_workflow:           'Greengage CI'
-          artifact_name:         'deb-packages'
+          artifact_name:         'deb-packages-ubuntu22.04'
           s3_prefix:             'ubuntu/22.04/x86_64'
           gh_token:              ${{ github.token }}
           aws_bucket:            ${{ secrets.BUCKET }}

--- a/examples/greengage-release.yml
+++ b/examples/greengage-release.yml
@@ -1,4 +1,4 @@
-# .github/workflows/greengage-release.yml
+# .github/workflows/greengage-release.yml EXAMPLE
 name: Greengage release
 
 on:
@@ -12,16 +12,24 @@ jobs:
       matrix:
         include:
         - version: 6
-          extensions: deb ddeb
-          artifact_name: deb-packages
+          target_os: ubuntu
+          target_os_version: '22.04'
+          extensions:  deb ddeb
+          package_dir: deb-packages
+        - version: 6
+          target_os: ubuntu
+          target_os_version: '24.04'
+          extensions:  deb ddeb
+          package_dir: deb-packages
     runs-on: ubuntu-24.04
     permissions:
       contents: write
       actions: read
     steps:
       - name: Upload packages to release
-        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v10
+        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v38
         with:
-          version: ${{ matrix.version }}
-          extensions: ${{ matrix.extensions }}
-          artifact_name: ${{ matrix.artifact_name }}
+          version:     ${{ matrix.version }}
+          extensions:  ${{ matrix.extensions }}
+          package_dir: ${{ matrix.package_dir }}
+          cache_key:   ${{ matrix.package_dir }}-${{ matrix.target_os }}${{ matrix.target_os_version }}-${{ github.sha }}


### PR DESCRIPTION
Packages for ubuntu 24.04 were not reaching the release. The build workflow used OS-agnostic names for both artifacts and cache, making multi-OS matrix builds impossible: on cache key collision the second save is silently skipped, and same-named artifacts are indistinguishable downstream.

- greengage-reusable-package: append target_os+target_os_version to artifact names and cache keys (e.g. deb-packages-ubuntu24.04-<sha>)
- upload-pkgs-to-release action: replace artifact_name with explicit cache_key and package_dir inputs — caller now owns key construction
- greengage-release example: expand matrix to ubuntu 22.04 and 24.04
- greengage-sync-packages: update artifact_name to deb-packages-ubuntu22.04

Task: CI-5752