### PR TITLE
CI-5781 Publish packages to repository consistently

### DIFF
--- a/.github/workflows/greengage-sync-packages.yml
+++ b/.github/workflows/greengage-sync-packages.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         include:
           - source_repo:   GreengageDB/greengage


### PR DESCRIPTION
### Publish packages to repository consistently (#59)

We got a broken index while uploading files in parallel mode,
because repomanager tool reads the metadata file from s3
everytime when uploads the package. So we publush packages
consistently to prevent metadata diff between uploads.

Task: CI-5781