### PR TITLE
fix(resgroup): copy ci directory contents instead of symlink inode

### DIFF
--- a/.github/workflows/greengage-reusable-tests-resgroup.yml
+++ b/.github/workflows/greengage-reusable-tests-resgroup.yml
@@ -104,14 +104,14 @@ jobs:
           systemctl enable --now docker
 
           cd /home/gpadmin
-          mkdir -p logs
+          mkdir -p logs ci
 
           docker load < $IMAGE_FILE
           rm $IMAGE_FILE
 
           # Extract test script from Image instaed of GIT
           docker create --name temp-container $IMAGE
-          docker cp temp-container:/home/gpadmin/gpdb_src/ci ./ci
+          docker cp temp-container:/home/gpadmin/gpdb_src/ci/. ./ci/
           docker rm temp-container
           EOF0
 


### PR DESCRIPTION
Use `docker cp ci/.` to copy the contents of the `ci` directory rather than the symlink object itself.

This fixes resgroup tests in QEMU/KVM environments where `ci` is a compatibility symlink to `arenadata`.

Task: [CI-5581](https://tracker.yandex.ru/CI-5581)