### PR TITLE
CI-5657: Add Rocky Linux support to reusable build workflow

### DIFF
--- a/.github/workflows/greengage-reusable-build.yml
+++ b/.github/workflows/greengage-reusable-build.yml
@@ -36,6 +36,7 @@ jobs:
       actions: write  # Required for cache
     env:
       IMAGE: ghcr.io/${{ github.repository }}/ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}
+      TARGET_OS:  ${{ inputs.target_os }}
       OS_VERSION: ${{ inputs.target_os_version || 22.04 }}
       SKIP_UNITTESTS: ${{ github.event_name != 'pull_request' && '1' || inputs.skip_unittests }}
     steps:
@@ -68,15 +69,22 @@ jobs:
       # Build Docker intermediate image with commit SHA tag
       - name: Build Docker image
         run: |
-          ubuntu_mirror_ip=$(host azure.archive.ubuntu.com | awk '/has address/{print $NF; exit}')
-          if curl -sf --max-time 5 "http://${ubuntu_mirror_ip}/ubuntu/" > /dev/null; then
-            docker_options="--add-host=archive.ubuntu.com:${ubuntu_mirror_ip} --add-host=security.ubuntu.com:${ubuntu_mirror_ip}"
-          fi
+          case "$TARGET_OS" in
+            ubuntu)
+              mirror_ip=$(host azure.archive.ubuntu.com | awk '/has address/{print $NF; exit}')
+              if curl -sf --max-time 5 "http://${mirror_ip}/ubuntu/" > /dev/null; then
+                docker_options="--add-host=archive.ubuntu.com:${mirror_ip} --add-host=security.ubuntu.com:${mirror_ip}"
+              fi
+              ;;
+            rockylinux)
+              # TODO: add Azure mirror for Rocky Linux if available
+              ;;
+          esac
           docker build $docker_options \
             --build-arg OS_VERSION \
             --build-arg SKIP_UNITTESTS \
             --tag ${IMAGE,,}:${{ github.sha }} \
-            -f ci/Dockerfile.${{ inputs.target_os }} \
+            -f ci/Dockerfile.$TARGET_OS \
             .
 
       # Push developer's and SHA tag image for internal PRs and pushes

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -64,7 +64,7 @@ jobs:
             -e BUILDNUMBER=${{ github.run_number }} \
             -e SKIP_UNITTESTS=1 \
             "${BUILDER,,}":${{ github.sha }} \
-            /bin/bash -c "unset CONFIGURE_FLAGS ; make -C ./gpdb_src/gpAux pkg-deb"
+            /bin/bash -c "unset CONFIGURE_FLAGS ; make -C ./gpdb_src/gpAux pkg"
       - name: Upload Debian artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -64,7 +64,7 @@ jobs:
             -e BUILDNUMBER=${{ github.run_number }} \
             -e SKIP_UNITTESTS=1 \
             "${BUILDER,,}":${{ github.sha }} \
-            /bin/bash -c "unset CONFIGURE_FLAGS ; make -C ./gpdb_src/gpAux pkg"
+            /bin/bash -c "unset CONFIGURE_FLAGS ; make -C ./gpdb_src/gpAux pkg-deb"
       - name: Upload Debian artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/README/REUSABLE-BUILD.md
+++ b/README/REUSABLE-BUILD.md
@@ -20,12 +20,12 @@ To integrate this workflow into your pipeline:
 
 ### Inputs
 
-| Name                | Description                                       | Required | Type    | Default |
-|---------------------|---------------------------------------------------|----------|---------|---------|
-| `version`           | Greengage version (e.g., `6` or `7`)              | Yes      | String  | -       |
-| `target_os`         | Target operating system (e.g., `ubuntu`)          | Yes      | String  | -       |
-| `target_os_version` | Target OS version (e.g., ``, `24.04`)             | No       | String  | `''`    |
-| `skip_unittests`    | Skip unit tests during build (set to `1` to skip) | No       | String  | `''`    |
+| Name                | Description                                            | Required | Type    | Default |
+|---------------------|--------------------------------------------------------|----------|---------|---------|
+| `version`           | Greengage version (e.g., `6` or `7`)                   | Yes      | String  | -       |
+| `target_os`         | Target operating system (e.g., `ubuntu`, `rockylinux`) | Yes      | String  | -       |
+| `target_os_version` | Target OS version (e.g., ``, `24.04`)                  | No       | String  | `''`    |
+| `skip_unittests`    | Skip unit tests during build (set to `1` to skip)      | No       | String  | `''`    |
 
 ### Secrets
 
@@ -40,7 +40,9 @@ To integrate this workflow into your pipeline:
 - **Dockerfile**: Ensure a Dockerfile exists at `ci/Dockerfile.<target_os>` (e.g., `ci/Dockerfile.ubuntu`). The `OS_VERSION` build argument is passed to the Dockerfile with a default value of `22.04` if `target_os_version` is not provided.
 - **Repository Access**: The workflow checks out the current branch of the repository specified in `github.repository`. For PRs, it uses `github.event.pull_request.head.sha`; otherwise, it uses `github.ref`.
 - **Disk Space**: The workflow uses the `greengagedb/greengage-ci/.github/actions/maximize-disk-space@v24` action to maximize available disk space before building.
-- **Ubuntu mirror**: During build, `azure.archive.ubuntu.com` is resolved and injected via `--add-host` for `archive.ubuntu.com` and `security.ubuntu.com`. Falls back to default mirrors if unreachable.
+- **OS-specific mirrors**: During build, mirror optimization is applied per target OS.
+  For `ubuntu`, `azure.archive.ubuntu.com` is resolved and injected via `--add-host` for `archive.ubuntu.com` and `security.ubuntu.com`, falling back to default mirrors if unreachable.
+  For other OSes (e.g., `rockylinux`), no mirror override is applied.
 - **Caching**: The built image is saved as a `.tar` file and cached using `actions/cache/save@v4` with a key matching the image tag.
 
 ### Examples


### PR DESCRIPTION
## Add Rocky Linux support to reusable build workflow

Scope OS-specific mirror optimization by target OS to support
non-Ubuntu builds without breaking existing Ubuntu behavior.

- Expose `TARGET_OS` as a job-level env var for use in shell scripts
- Replace unconditional Ubuntu mirror resolution with a `case` statement:
  Ubuntu keeps the existing Azure mirror optimization, Rocky Linux has
  a stub for a future mirror when available
- Use `$TARGET_OS` instead of expression interpolation in `docker build`

Task: CI-5657