### PR TITLE
CI-5861: Refactor Release workflow

### DIFF
--- a/.github/actions/tests/install/deb/action.yml
+++ b/.github/actions/tests/install/deb/action.yml
@@ -29,7 +29,7 @@ runs:
   using: composite
   steps:
     - name: Download deb artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.artifact_name }}
         path: deb-packages

--- a/.github/actions/upload-pkgs-to-release/README.md
+++ b/.github/actions/upload-pkgs-to-release/README.md
@@ -4,7 +4,7 @@ This composite GitHub Action orchestrates the package release process by coordin
 
 ## Actual version
 
-- `greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release/action.yaml@v38`
+- `greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release/action.yaml@v45`
 
 ## Workflow Coordination Model
 
@@ -16,50 +16,35 @@ This composite GitHub Action orchestrates the package release process by coordin
    - Verifies the workflow completed successfully for the exact commit and tag
    - Provides configurable timeout (default: 4 hours) and polling interval (default: 60 seconds)
 
-2. **Restore Built Packages from Cache**
+2. **Download Built Packages**
 
-   - Retrieves packages from GitHub Actions cache using the explicit cache key passed by the caller
-   - Cache key format: `{package_dir}-{target_os}{target_os_version}-{commit_sha}`
+   - **Primary**: downloads the artifact `{artifact_prefix}-{target_os}{target_os_version}` from the CI run using `gh run download`
+   - **Fallback**: if the artifact is not found, restores from GitHub Actions cache using key `{artifact_prefix}-{target_os}{target_os_version}-{commit_sha}` — preserves backward compatibility with workflows that do not yet produce artifacts
 
-3. **Create Release if Needed**
+3. **Rename and Upload Packages**
 
-   - Creates GitHub release when `create_force` is specified and release doesn't exist
-   - Includes build metadata (commit SHA, workflow run ID) in release notes
-
-4. **Upload Packages with Original Names**
-
-   - Uploads packages to release preserving their original filenames
+   - Renames each file to include the OS revision suffix before upload:
+     `{name}_{version}_{arch}.deb` → `{name}_{version}~{target_os}{target_os_version}_{arch}.deb`
+   - Uploads all matching files to the release
    - Optional overwrite with `clobber` flag
 
 ## Inputs
 
 Name                   | Required | Default        | Description
 ---------------------- | -------- | -------------- | ----------------------------------------------------------------
-`cache_key`            | **yes**  |                | Full cache key used to restore built packages
-`package_dir`          | no       | `Packages`     | Local directory name where cache is restored (must match the build workflow)
-`package_name`         | no       | repo name      | Base package name for release notes
-`release_name`         | no       | current tag    | Target release name (defaults to current tag)
-`version`              | no       | empty          | Version string appended to package name in release notes
+`target_os`            | **yes**  |                | Target OS (e.g. `ubuntu`)
+`target_os_version`    | **yes**  |                | Target OS version (e.g. `22.04`, `24.04`)
+`artifact_prefix`      | **yes**  |                | Artifact name prefix. Full name: `{prefix}-{target_os}{target_os_version}`. Also used as the local download directory.
 `extensions`           | no       | `deb ddeb rpm` | Space-separated list of package file extensions to upload
-`create_force`         | no       | empty          | Force release creation if it doesn't exist
-`clobber`              | no       | `false`        | Overwrite existing release assets
+`clobber`              | no       | empty          | Set to `true` to overwrite existing release assets
 `ci_wait_timeout`      | no       | `14400`        | Timeout in seconds to wait for CI workflow (4 hours)
 `ci_poll_interval`     | no       | `60`           | Poll interval in seconds to check CI workflow status
 `workflow_for_waiting` | no       | `Greengage CI` | **Name of the package building workflow** to wait for completion
 
-## Key Features
-
-- **Workflow Coordination**: Ensures package building completes successfully before release upload
-- **Build Status Verification**: Uses GitHub CLI to confirm successful build for specific commit/tag
-- **Cache-based Artifact Transfer**: Reliable package transfer between workflows via GitHub Actions cache
-- **Explicit Cache Keys**: Caller constructs and passes the cache key, keeping naming conventions in the calling workflow
-- **Configurable Timeouts**: Adjustable wait times for CI workflow completion
-- **Manual Recovery Flow**: Clear instructions when cache restoration fails
-
 ## Usage Example
 
 ```yaml
-name: Greengage release
+name: Greengage PXF Release
 on:
   release:
     types: [released]
@@ -69,28 +54,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - version: 6
-          target_os: ubuntu
-          target_os_version: '22.04'
-          extensions:  deb ddeb
-          package_dir: deb-packages
-        - version: 6
-          target_os: ubuntu
-          target_os_version: '24.04'
-          extensions:  deb ddeb
-          package_dir: deb-packages
-    runs-on: ubuntu-24.04
+        - target_os: ubuntu
+          target_os_version: 22.04
+          extensions:       deb ddeb
+          artifact_prefix:  deb-packages-pxf6
+        - target_os: ubuntu
+          target_os_version: 24.04
+          extensions:       deb ddeb
+          artifact_prefix:  deb-packages-pxf6
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       actions: read
     steps:
       - name: Upload packages to release
-        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v38
+        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v45
         with:
-          version:     ${{ matrix.version }}
-          extensions:  ${{ matrix.extensions }}
-          package_dir: ${{ matrix.package_dir }}
-          cache_key:   ${{ matrix.package_dir }}-${{ matrix.target_os }}${{ matrix.target_os_version }}-${{ github.sha }}
+          workflow_for_waiting: Greengage PXF CI
+          target_os:            ${{ matrix.target_os }}
+          target_os_version:    ${{ matrix.target_os_version }}
+          extensions:           ${{ matrix.extensions }}
+          artifact_prefix:      ${{ matrix.artifact_prefix }}
 ```
 
 ## How It Works: Wait for Package Building
@@ -105,7 +89,7 @@ The action waits for the **package generation workflow** to complete before proc
 
 2. **Monitors workflow status** until:
 
-   - **Success**: Proceeds with cache restoration and upload
+   - **Success**: Proceeds with package download and upload
    - **Failure**: Exits with error and link to failed run
    - **Timeout**: Exits after specified wait time
 
@@ -120,8 +104,7 @@ Scenario                                           | Action                     
 -------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------
 Package building workflow not found within timeout | Exit with timeout error                          | Check workflow name/trigger conditions
 Package building workflow failed                   | Exit with failure details                        | Fix build issues and restart
-Cache miss after successful build                  | Provide rebuild instructions with link to CI run | Manually trigger "Re-run all jobs" on build workflow
-Release doesn't exist and `create_force` not set   | Skip upload                                      | Set `create_force: true` or create release manually
+Artifact and cache both missing                    | Exit with error and link to CI run               | Re-run the CI workflow for the same tag
 
 ## Package Building Workflow Requirements
 
@@ -129,22 +112,12 @@ For this action to work correctly, the package building workflow must:
 
 1. **Use the same commit SHA** as the release workflow
 2. **Be triggered by push events** to the release tag
-3. **Store packages in cache** with key format: `{package_dir}-{target_os}{target_os_version}-{commit_sha}`
-4. **Use unique cache keys per OS/version** when building for multiple targets in a matrix
-5. **Complete successfully** before the release workflow proceeds
-
-## Technical Implementation
-
-- **GitHub CLI Filtering**: Uses `gh run list --jq` with precise filtering to find the correct workflow run
-- **Explicit Cache Key**: Caller passes the full `cache_key`; action does not construct it internally, keeping naming conventions co-located with the build matrix
-- **Package Validation**: Verifies exactly one file per extension before upload
-- **Original Filename Preservation**: Files are uploaded with their original names from the cache
-- **Release Metadata**: Includes build provenance in release notes
+3. **Upload packages as a GitHub Actions artifact** named `{artifact_prefix}-{target_os}{target_os_version}`
+4. **Complete successfully** before the release workflow proceeds
 
 ## Notes
 
-- **Cache Key Convention**: The key must match exactly what the build workflow saves. Recommended format: `{package_dir}-{target_os}{target_os_version}-{github.sha}`
-- **Workflow Names**: Ensure `workflow_for_waiting` matches the exact name of your package building workflow
-- **Permissions**: Requires `GH_TOKEN` with `actions:read` and `contents:write` scopes
-- **Concurrency**: Consider using concurrency groups to prevent race conditions between workflows
-- **Cache Expiration**: GitHub Actions cache expires after 7 days; ensure releases are published within this window after the build
+- **Artifact naming**: the artifact name must match `{artifact_prefix}-{target_os}{target_os_version}` exactly
+- **Cache fallback**: if the CI workflow saves packages to cache with key `{artifact_prefix}-{target_os}{target_os_version}-{sha}`, the action will use it as a fallback automatically
+- **Workflow Names**: ensure `workflow_for_waiting` matches the exact name of your package building workflow
+- **Permissions**: requires `GH_TOKEN` with `actions:read` and `contents:write` scopes

--- a/.github/actions/upload-pkgs-to-release/action.yaml
+++ b/.github/actions/upload-pkgs-to-release/action.yaml
@@ -1,5 +1,6 @@
+# .github/actions/upload-pkgs-to-release/action.yaml
 name: Upload Packages to GitHub Release
-description: "Create or update a GitHub release and upload packages with fixed names"
+description: "Waits for CI workflow completion, downloads built packages and uploads them to the release"
 
 inputs:
   target_os:
@@ -8,42 +9,29 @@ inputs:
   target_os_version:
     description: 'Target OS version (e.g. 22.04)'
     required: true
-  package_dir:
-    description: 'Local directory where cached packages are restored'
-    required: false
-    default: 'Packages'
-  package_name:
-    description: 'Base package name, defaults to repository name'
-    required: false
-    default: ''
-  release_name:
-    description: 'Target release name, defaults to current tag'
-    required: false
-    default: ''
-  version:
-    description: 'Version string to append to package name'
-    required: false
-    default: ''
+  artifact_prefix:
+    description: |
+      Artifact name prefix. The full artifact name is constructed as
+      {artifact_prefix}-{target_os}{target_os_version}
+      (e.g. 'deb-packages-pxf6' -> 'deb-packages-pxf6-ubuntu22.04').
+      Also used as the local directory for downloaded packages.
+    required: true
   extensions:
     description: 'Space-separated list of package file extensions'
     required: false
     default: 'deb ddeb rpm'
-  create_force:
-    description: 'Force create the release if not exists, defaults false'
-    required: false
-    default: ''
   clobber:
-    description: 'Overwrite existing assets if they exist. Defaults to false (skip if exists)'
+    description: 'Overwrite existing assets if they exist'
     required: false
     default: ''
   ci_wait_timeout:
     description: 'Timeout in seconds to wait for CI workflow'
     required: false
-    default: '14400'  # 4 hours
+    default: '14400'
   ci_poll_interval:
     description: 'Poll interval in seconds to check CI workflow status'
     required: false
-    default: '60'  # 1 minute
+    default: '60'
   workflow_for_waiting:
     description: 'Packages generation workflow name for waiting'
     required: false
@@ -57,14 +45,6 @@ runs:
       with:
         submodules: recursive
 
-    - name: Debug ref context RESTORE ACTION
-      shell: bash
-      run: |
-        echo "Current ref: ${{ github.ref }}"
-        echo "Current ref_name: ${{ github.ref_name }}"
-        echo "Current sha: ${{ github.sha }}"
-        echo "Event name: ${{ github.event_name }}"
-
     - name: Wait for package generation workflow completion
       shell: bash
       env:
@@ -73,6 +53,7 @@ runs:
         POLL_INTERVAL: ${{ inputs.ci_poll_interval }}
         WORKFLOW: ${{ inputs.workflow_for_waiting }}
       run: |
+        set -euo pipefail
         start_time=$(date +%s)
 
         while true; do
@@ -85,123 +66,101 @@ runs:
           fi
 
           result=$(gh run list --workflow "$WORKFLOW" --limit 100 \
-            --json conclusion,headSha,event,headBranch,url,status \
+            --json conclusion,headSha,event,headBranch,url,status,databaseId \
             --jq '
               map(select(
                 .headSha == "'"${{ github.sha }}"'" and
                 .event == "push" and
                 .headBranch == "'"${{ github.event.release.tag_name }}"'"
-              )) |
-              .[0]
+              )) | .[0]
             ')
 
           if [ -z "$result" ] || [ "$result" = "null" ]; then
             echo "CI workflow not found yet. Waiting... (${remaining}s remaining)"
-            sleep $POLL_INTERVAL
+            sleep "$POLL_INTERVAL"
             continue
           fi
 
           status=$(echo "$result" | jq -r '.status // empty')
           conclusion=$(echo "$result" | jq -r '.conclusion // empty')
           run_url=$(echo "$result" | jq -r '.url')
+          run_id=$(echo "$result" | jq -r '.databaseId')
 
           if [ "$status" = "completed" ] && [ "$conclusion" = "success" ]; then
-            echo "CI_WORKFLOW_URL=$run_url" >> $GITHUB_ENV
+            echo "CI_WORKFLOW_URL=$run_url" >> "$GITHUB_ENV"
+            echo "CI_RUN_ID=$run_id"       >> "$GITHUB_ENV"
             break
           fi
 
-          if [ "$status" = "in_progress" ] || [ "$status" = "queued" ] || [ "$status" = "waiting" ] || [ "$status" = "pending" ]; then
+          if [ "$status" = "in_progress" ] || [ "$status" = "queued" ] || \
+             [ "$status" = "waiting" ]     || [ "$status" = "pending" ]; then
             echo "Current status: '$status'. Continue waiting... (${remaining}s remaining)"
-            sleep $POLL_INTERVAL
+            sleep "$POLL_INTERVAL"
             continue
           fi
 
-          echo "ERROR: CI workflow failed or was skipped. Failed run url: '$run_url'"
+          echo "ERROR: CI workflow failed or was skipped. Run: '$run_url'"
           jq <<< "$result"
           exit 1
         done
 
-    - name: Restore Package artifacts from cache
+    - name: Download artifact from CI run
+      id: download
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        ARTIFACT_NAME="${{ inputs.artifact_prefix }}-${{ inputs.target_os }}${{ inputs.target_os_version }}"
+
+        echo "Trying to download artifact '$ARTIFACT_NAME' from run $CI_RUN_ID..."
+
+        if gh run download "$CI_RUN_ID" \
+          --name "$ARTIFACT_NAME" \
+          --dir "${{ inputs.artifact_prefix }}"; then
+          echo "source=artifact" >> "$GITHUB_OUTPUT"
+        else
+          echo "Artifact not found, will try cache fallback"
+          echo "source=cache" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Restore packages from cache (fallback)
+      if: steps.download.outputs.source == 'cache'
       uses: actions/cache/restore@v4
       id: cache-restore
       with:
-        path: ${{ inputs.package_dir }}
-        key:  ${{ inputs.package_dir }}-${{ inputs.target_os }}${{ inputs.target_os_version }}-${{ github.sha }}
+        path: ${{ inputs.artifact_prefix }}
+        key:  ${{ inputs.artifact_prefix }}-${{ inputs.target_os }}${{ inputs.target_os_version }}-${{ github.sha }}
 
-    - name: Handle cache miss or restore failure
-      if: steps.cache-restore.outputs.cache-hit != 'true'
+    - name: Handle artifact and cache miss
+      if: |
+        steps.download.outputs.source == 'cache' &&
+        steps.cache-restore.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        echo "ERROR: Cache missed but last build succeeded. No artifacts found for tag: '${{ github.event.release.tag_name }}'"
-        echo "Please go to ${CI_WORKFLOW_URL:-the CI workflow run} and click 'Re-run all jobs' to rebuild cache"
+        echo "ERROR: Both artifact download and cache restore failed."
+        echo "No packages found for tag '${{ github.event.release.tag_name }}'"
+        echo "Please re-run the CI workflow: ${CI_WORKFLOW_URL:-unknown}"
         exit 1
 
     - name: List downloaded files
       shell: bash
-      run: find "${{ inputs.package_dir }}" -type f
-
-    - name: Create release if not exists
-      if: inputs.create_force != ''
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-        RELEASE_NAME: ${{ inputs.release_name }}
-        PACKAGE_NAME: ${{ inputs.package_name }}
-      run: |
-        PACKAGE_NAME=${PACKAGE_NAME:-${GITHUB_REPOSITORY#*/}}
-        RELEASE_NAME=${RELEASE_NAME:-${GITHUB_REF#refs/tags/}}
-
-        for var in PACKAGE_NAME RELEASE_NAME ; do
-          if [ -z "${!var}" ] ; then
-            echo "Can't determine $var"
-            exit 1
-          fi
-        done
-
-        if ! gh release view "$RELEASE_NAME" > /dev/null 2>&1; then
-          gh release create "$RELEASE_NAME" \
-            --title "Release $RELEASE_NAME" \
-            --notes "$PACKAGE_NAME $RELEASE_NAME
-        Built from commit: $GITHUB_SHA
-        Workflow run: $GITHUB_RUN_NUMBER"
-        else
-          echo "Release $RELEASE_NAME already exists, skipping creation."
-        fi
-
-    - name: Check release exists
-      shell: bash
-      id: check_release
-      env:
-        GH_TOKEN: ${{ github.token }}
-        RELEASE_NAME: ${{ inputs.release_name }}
-      run: |
-        RELEASE_NAME="${RELEASE_NAME:-${GITHUB_REF#refs/tags/}}"
-        if gh release view "$RELEASE_NAME" > /dev/null 2>&1; then
-          echo "Release '$RELEASE_NAME' exists, proceeding with upload"
-          echo "exists=true" >> $GITHUB_OUTPUT
-        else
-          echo "Release '$RELEASE_NAME' not found, skipping upload"
-        fi
+      run: find "${{ inputs.artifact_prefix }}" -type f
 
     - name: Upload packages
-      if: steps.check_release.outputs.exists == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-        RELEASE_NAME: ${{ inputs.release_name }}
+        RELEASE_NAME: ${{ github.ref_name }}
         REVISION: ${{ inputs.target_os }}${{ inputs.target_os_version }}
       run: |
-        RELEASE_NAME=${RELEASE_NAME:-${GITHUB_REF#refs/tags/}}
-
-        if [ -z "$RELEASE_NAME" ] ; then
-          echo "Can't determine RELEASE_NAME"
-          exit 1
-        fi
-
+        set -euo pipefail
         shopt -s nullglob
 
+        not_uploaded=''
         for ext in ${{ inputs.extensions }}; do
-          files=("${{ inputs.package_dir }}"/*.$ext)
+          files=("${{ inputs.artifact_prefix }}"/*.$ext)
           if [ ${#files[@]} -ne 1 ]; then
             echo "Expected exactly one *.$ext file, found ${#files[@]}"
             exit 1
@@ -210,13 +169,16 @@ runs:
           f="${files[0]}"
           base="${f%.$ext}"
           arch="${base##*_}"
-          mv ${base%_$arch}{,~${REVISION}}_${arch}.${ext}
+          mv "${base%_$arch}"{,~${REVISION}}"_${arch}.${ext}"
           f="${base%_$arch}~${REVISION}_${arch}.${ext}"
 
           echo "Uploading $f"
-          gh release upload "$RELEASE_NAME" "$f" ${{ inputs.clobber == 'true' && '--clobber' || '' }} || not_uploaded=${not_uploaded:+$not_uploaded, }$ext
+          gh release upload "$RELEASE_NAME" "$f" \
+            ${{ inputs.clobber == 'true' && '--clobber' || '' }} \
+            || not_uploaded="${not_uploaded:+$not_uploaded, }$ext"
         done
-        if [ -n "$not_uploaded" ] ; then
-          echo "The following extension(s) are not uploaded: $not_uploaded"
+
+        if [ -n "$not_uploaded" ]; then
+          echo "The following extension(s) were not uploaded: $not_uploaded"
           exit 1
         fi

--- a/.github/actions/upload-pkgs-to-release/action.yaml
+++ b/.github/actions/upload-pkgs-to-release/action.yaml
@@ -41,7 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: recursive
 
@@ -127,7 +127,7 @@ runs:
 
     - name: Restore packages from cache (fallback)
       if: steps.download.outputs.source == 'cache'
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       id: cache-restore
       with:
         path: ${{ inputs.artifact_prefix }}

--- a/.github/actions/upload-pkgs-to-release/action.yaml
+++ b/.github/actions/upload-pkgs-to-release/action.yaml
@@ -161,24 +161,25 @@ runs:
         not_uploaded=''
         for ext in ${{ inputs.extensions }}; do
           files=("${{ inputs.artifact_prefix }}"/*.$ext)
-          if [ ${#files[@]} -ne 1 ]; then
-            echo "Expected exactly one *.$ext file, found ${#files[@]}"
-            exit 1
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No *.$ext files found, skipping"
+            continue
           fi
 
-          f="${files[0]}"
-          base="${f%.$ext}"
-          arch="${base##*_}"
-          mv "${base%_$arch}"{,~${REVISION}}"_${arch}.${ext}"
-          f="${base%_$arch}~${REVISION}_${arch}.${ext}"
+          for f in "${files[@]}"; do
+            base="${f%.$ext}"
+            arch="${base##*_}"
+            mv "${base%_$arch}"{,~${REVISION}}"_${arch}.${ext}"
+            f="${base%_$arch}~${REVISION}_${arch}.${ext}"
 
-          echo "Uploading $f"
-          gh release upload "$RELEASE_NAME" "$f" \
-            ${{ inputs.clobber == 'true' && '--clobber' || '' }} \
-            || not_uploaded="${not_uploaded:+$not_uploaded, }$ext"
+            echo "Uploading $f"
+            gh release upload "$RELEASE_NAME" "$f" \
+              ${{ inputs.clobber == 'true' && '--clobber' || '' }} \
+              || not_uploaded="${not_uploaded:+$not_uploaded, }$f"
+          done
         done
 
         if [ -n "$not_uploaded" ]; then
-          echo "The following extension(s) were not uploaded: $not_uploaded"
+          echo "The following files were not uploaded: $not_uploaded"
           exit 1
         fi

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -16,11 +16,15 @@ on:
         required: false
         type: string
         default: ''
-      rebuild_builder:
-        description: 'Rebuild builder image required'
+      artifact_prefix:
+        description: |
+          Artifact name prefix. The full artifact name is constructed as
+          {artifact_prefix}-{target_os}{target_os_version}
+          (e.g. 'deb-packages-greengage6' -> 'deb-packages-greengage6-ubuntu22.04').
+          Also used as the local directory for downloaded packages.
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: 'deb-packages'
       test_docker:
         description: 'Docker Image (e.g., ubuntu:22.04, ubuntu:noble) for deploy test. Skip if empty'
         required: false
@@ -55,7 +59,7 @@ jobs:
           BUILDER: ghcr.io/${{ github.repository }}/ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}
         run: |
           docker run --rm \
-            -v ./deb-packages:/home/gpadmin/gpdb_src/Package \
+            -v ./${{ inputs.artifact_prefix }}:/home/gpadmin/gpdb_src/Package \
             -e BUILDNUMBER=${{ github.run_number }} \
             -e SKIP_UNITTESTS=1 \
             "${BUILDER,,}":${{ github.sha }} \
@@ -63,14 +67,8 @@ jobs:
       - name: Upload Debian artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: deb-packages-${{ inputs.target_os }}${{ inputs.target_os_version || '22.04' }}
-          path: deb-packages
-
-      - name: Cache Debian artifacts
-        uses: actions/cache/save@v4
-        with:
-          path: deb-packages
-          key:  deb-packages-${{ inputs.target_os }}${{ inputs.target_os_version || '22.04' }}-${{ github.sha }}
+          name: ${{ inputs.artifact_prefix }}-${{ inputs.target_os }}${{ inputs.target_os_version || '22.04' }}
+          path: ${{ inputs.artifact_prefix }}
 
   test-docker:
     if: inputs.test_docker != ''
@@ -81,7 +79,7 @@ jobs:
         uses: greengagedb/greengage-ci/.github/actions/tests/install/deb@v44
         with:
           test_docker: ${{ inputs.test_docker }}
-          artifact_name: deb-packages-${{ inputs.target_os }}${{ inputs.target_os_version || '22.04' }}
+          artifact_name: ${{ inputs.artifact_prefix }}-${{ inputs.target_os }}${{ inputs.target_os_version || '22.04' }}
           verify_commands: |
             dpkg -l sigar 2>/dev/null || true
             dpkg -l greengage*

--- a/README/REUSABLE-PACKAGE.md
+++ b/README/REUSABLE-PACKAGE.md
@@ -1,72 +1,63 @@
 # Greengage Reusable Package Workflow
 
-This workflow builds and packages Debian (.deb) packages for the Greengage project and optionally tests their installation in a Docker environment. It is designed to be called from a parent CI pipeline, providing flexibility for version, target operating system, and testing configurations.
+This workflow builds Debian (.deb) packages for the Greengage project
+and optionally tests their installation in a Docker environment.
+It is designed to be called from a parent CI pipeline.
 
 ## Actual version
 
-- `greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v44`
+- `greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v45`
 
 ## Purpose
 
-The workflow performs the following tasks:
-
-- `build-deb`: Builds Debian packages for the specified Greengage version and target operating system (Ubuntu).
-- `test-docker`: Tests installation of the generated Debian packages in a Docker container (if specified).
+- **`build-deb`**: Builds Debian packages for the specified Greengage
+  version and target OS, uploads them as a GitHub Actions artifact.
+- **`test-docker`**: Tests installation of the generated packages in a
+  Docker container (if `test_docker` is provided).
 
 ### Algorithm
 
 1. **Build Debian Packages** (`build-deb`):
 
-   - Logs into the GitHub Container Registry (GHCR) using the provided token.
-   - Restores and loads the builder Docker image (`ghcr.io/<repo>/ggdb<version>_<target_os><target_os_version>:<sha>`) from cache or GHCR using the [`restore-load-image`](.github/actions/restore-load-image/action.yml) action.
-   - Runs the builder image to compile Debian packages using `make -C gpdb_src/gpAux pkg-deb`.
-   - Uploads generated artifacts as `deb-packages-<target_os><target_os_version>`.
-   - Caches artifacts by `<target_os><target_os_version>-<sha>` key for subsequent jobs.
+   - Restores and loads the builder Docker image from cache or GHCR
+     using the [`restore-load-image`](.github/actions/restore-load-image/action.yml) action.
+   - Runs the builder image to compile Debian packages via
+     `make -C gpdb_src/gpAux pkg-deb`.
+   - Uploads generated packages as artifact named
+     `{artifact_prefix}-{target_os}{target_os_version}`
+     (e.g. `deb-packages-ubuntu22.04`).
 
 2. **Test Installation in Docker** (`test-docker`, if `test_docker` is provided):
 
-   - Uses the [`tests/install/deb`](.github/actions/tests/install/deb/action.yml) composite action.
-   - Downloads the artifact, runs the specified Docker image, adds the Greengage apt repository, and installs the packages.
+   - Uses the [`tests/install/deb`](.github/actions/tests/install/deb/action.yml) action.
+   - Downloads the artifact, runs the specified Docker image, adds the
+     Greengage apt repository, and installs the packages.
 
 3. **Failure Conditions**:
 
    - If `target_os` is not `ubuntu`, the `build-deb` job is skipped.
-   - If the builder image cannot be restored or loaded, the `build-deb` job exits with an error.
-   - If the Debian package build fails, the `build-deb` job exits with an error.
-   - If `ghcr_token` is invalid or lacks permissions, GHCR login fails, causing the workflow to exit.
+   - If the builder image cannot be restored or loaded, the job exits with an error.
+   - If the Debian package build fails, the job exits with an error.
 
-## Usage
+## Inputs
 
-To integrate this workflow into your pipeline:
+| Name                | Description                                                                 | Required | Default        |
+|---------------------|-----------------------------------------------------------------------------|----------|----------------|
+| `version`           | Greengage version (e.g., `6` or `7`)                                        | yes      | —              |
+| `target_os`         | Target operating system (e.g., `ubuntu`)                                    | yes      | —              |
+| `target_os_version` | Target OS version (e.g., `24.04`). Defaults to `22.04` if empty.            | no       | `''`           |
+| `artifact_prefix`   | Artifact name prefix. Full name: `{prefix}-{target_os}{target_os_version}`. | no       | `deb-packages` |
+| `test_docker`       | Docker image for install test (e.g., `ubuntu:22.04`). Skipped if empty.     | no       | `''`           |
 
-1. Add a job in your parent workflow that calls this reusable workflow.
-2. Provide the required and optional inputs as described below.
-3. Ensure the necessary permissions and secrets are configured.
-
-### Inputs
-
-| Name                | Description                                          | Required | Type    | Default |
-|---------------------|------------------------------------------------------|----------|---------|---------|
-| `version`           | Greengage version (e.g., `6` or `7`)                 | Yes      | String  | -       |
-| `target_os`         | Target operating system (e.g., `ubuntu`)             | Yes      | String  | -       |
-| `target_os_version` | Target OS version (e.g., ``, `24.04`)                | No       | String  | `''`    |
-| `rebuild_builder`   | Rebuild builder image even if it exists              | No       | Boolean | `false` |
-| `test_docker`       | Docker image (e.g., `ubuntu:22.04`) for deploy test  | No       | String  | `''`    |
-
-### Secrets
+## Secrets
 
 | Name         | Description                  | Required |
 |--------------|------------------------------|----------|
-| `ghcr_token` | GitHub token for GHCR access | Yes      |
+| `ghcr_token` | GitHub token for GHCR access | yes      |
 
-### Requirements
+## Usage
 
-- **Permissions**: The job requires `contents: read`, `packages: write`, and `actions: write` permissions.
-- **Secrets**: Provide a `GITHUB_TOKEN` with sufficient permissions as the `ghcr_token` secret.
-
-### Examples
-
-#### Single
+### Single
 
 ```yaml
 jobs:
@@ -75,7 +66,7 @@ jobs:
       contents: read
       packages: write
       actions: write
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v44
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v45
     with:
       version: 6
       target_os: ubuntu
@@ -84,7 +75,7 @@ jobs:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-#### Matrix
+### Matrix
 
 ```yaml
 jobs:
@@ -100,18 +91,33 @@ jobs:
       contents: read
       packages: write
       actions: write
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v44
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v45
     with:
-      version: 6
-      target_os: ${{ matrix.target_os }}
-      target_os_version: ${{ matrix.target_os_version }}
-      test_docker: ubuntu:${{ matrix.target_os_version || '22.04' }}
+      version:             6
+      target_os:           ${{ matrix.target_os }}
+      target_os_version:   ${{ matrix.target_os_version }}
+      test_docker:         ${{ matrix.target_os }}:${{ matrix.target_os_version }}
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-### Notes
+### Custom artifact prefix
+
+```yaml
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v45
+    with:
+      version:         6
+      target_os:       ubuntu
+      artifact_prefix: deb-packages-greengage6
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Notes
 
 - The `build-deb` job is skipped if `target_os` is not `ubuntu`.
 - If `test_docker` is empty, the test job is skipped.
-- For further details, refer to the workflow file in the `.github/workflows/` directory.
+- Artifact name convention: `{artifact_prefix}-{target_os}{target_os_version}`,
+  e.g. `deb-packages-ubuntu22.04` or `deb-packages-greengage6-ubuntu22.04`.
+- The `upload-pkgs-to-release` action expects the artifact name to follow
+  this convention — ensure `artifact_prefix` matches between workflows.


### PR DESCRIPTION
## CI-5861: Refactor Release workflow (#67)

Add artifact fallback for deb package delivery to Release

### upload-pkgs-to-release/action.yaml

- Rename `package_dir` input to `artifact_prefix` with a descriptive
  doc comment explaining how the full artifact name is constructed
- Remove unused inputs: `version`, `package_name`, `release_name`,
  `create_force`
- Remove release creation and existence check steps - the release is
  guaranteed to exist since the action is triggered by the release event
- Remove debug ref context step
- Add `databaseId` to CI run query to capture the run ID
- Add primary delivery via `gh run download` from the CI run artifact
- Demote cache restore to fallback for backward compatibility with
  workflows that do not yet produce artifacts
- Support multiple packages per extension - replace single-file assertion
  with an inner loop over all matching files
- Add `set -euo pipefail`, quote variables, initialize `not_uploaded`
  explicitly, simplify `RELEASE_NAME` to `github.ref_name`

### greengage-reusable-package.yml

- Add `artifact_prefix` input to allow overriding the artifact name prefix.
  Full artifact name is constructed as `{artifact_prefix}-{target_os}{target_os_version}`.
  Defaults to `deb-packages` to preserve backward compatibility.
- Remove `rebuild_builder` input - no longer needed.
- Remove `cache/save` step - packages are now delivered via artifacts,
  cache is no longer used as the primary transfer mechanism.
- Use `artifact_prefix` consistently in volume mount, artifact upload,
  and install test steps.

Task: [CI-5861](https://tracker.yandex.ru/CI-5861)